### PR TITLE
Relay supported fee assets

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,7 @@ type SourceSubnet struct {
 	APINodeHost       string                           `mapstructure:"api-node-host" json:"api-node-host"`
 	APINodePort       uint32                           `mapstructure:"api-node-port" json:"api-node-port"`
 	EncryptConnection bool                             `mapstructure:"encrypt-connection" json:"encrypt-connection"`
+	RPCEndpoint 	  string 						   `mapstructure:"rpc-endpoint" json:"rpc-endpoint"`
 	WSEndpoint        string                           `mapstructure:"ws-endpoint" json:"ws-endpoint"`
 	MessageContracts  map[string]MessageProtocolConfig `mapstructure:"message-contracts" json:"message-contracts"`
 }
@@ -283,6 +284,23 @@ func constructURL(protocol string, host string, port uint32, encrypt bool) strin
 // Otherwise, constructs the endpoint from the APINodeHost, APINodePort, and EncryptConnection fields,
 // following the /ext/bc/{chainID}/rpc format.
 func (s *DestinationSubnet) GetNodeRPCEndpoint() string {
+	if s.RPCEndpoint != "" {
+		return s.RPCEndpoint
+	}
+	baseUrl := constructURL("http", s.APINodeHost, s.APINodePort, s.EncryptConnection)
+	chainID := s.ChainID
+	subnetID, _ := ids.FromString(s.SubnetID) // already validated in Validate()
+	if subnetID == constants.PrimaryNetworkID {
+		chainID = cChainIdentifierString
+	}
+	return fmt.Sprintf("%s/ext/bc/%s/rpc", baseUrl, chainID)
+}
+
+// Constructs an RPC endpoint for the subnet.
+// If the RPCEndpoint field is set in the configuration, returns that directly.
+// Otherwise, constructs the endpoint from the APINodeHost, APINodePort, and EncryptConnection fields,
+// following the /ext/bc/{chainID}/rpc format.
+func (s *SourceSubnet) GetNodeRPCEndpoint() string {
 	if s.RPCEndpoint != "" {
 		return s.RPCEndpoint
 	}

--- a/messages/message_manager.go
+++ b/messages/message_manager.go
@@ -27,12 +27,14 @@ type MessageManager interface {
 }
 
 // NewMessageManager constructs a MessageManager for a particular message protocol, defined by the message protocol address and config
+// [sourceSubnetInfo] is an optional parameter that may be used to construct a source node client, if needed
 // Note that DestinationClients may be invoked concurrently by many MessageManagers, so it is assumed that they are implemented in a thread-safe way
 func NewMessageManager(
 	logger logging.Logger,
 	messageProtocolAddress common.Hash,
 	messageProtocolConfig config.MessageProtocolConfig,
 	destinationClients map[ids.ID]vms.DestinationClient,
+	sourceSubnetInfo config.SourceSubnet,
 ) (MessageManager, error) {
 	format := messageProtocolConfig.MessageFormat
 	switch config.ParseMessageProtocol(format) {
@@ -41,6 +43,7 @@ func NewMessageManager(
 			messageProtocolAddress,
 			messageProtocolConfig,
 			destinationClients,
+			sourceSubnetInfo,
 		)
 	default:
 		return nil, fmt.Errorf("invalid message format %s", format)

--- a/messages/teleporter/config.go
+++ b/messages/teleporter/config.go
@@ -9,13 +9,21 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
+// Teleporter configuration.
+// If FeeAssets is empty, than the relayer will relay all messages, regardless of fee asset.
 type Config struct {
-	RewardAddress string `json:"reward-address"`
+	RewardAddress string   `json:"reward-address"`
+	FeeAssets     []string `json:"fee-assets"`
 }
 
 func (c *Config) Validate() error {
 	if !common.IsHexAddress(c.RewardAddress) {
 		return fmt.Errorf("invalid reward address for EVM source subnet: %s", c.RewardAddress)
+	}
+	for _, asset := range c.FeeAssets {
+		if !common.IsHexAddress(asset) {
+			return fmt.Errorf("invalid fee asset address for EVM source subnet: %s", asset)
+		}
 	}
 	return nil
 }

--- a/messages/teleporter/message.go
+++ b/messages/teleporter/message.go
@@ -28,6 +28,11 @@ type TeleporterMessageReceipt struct {
 	RelayerRewardAddress common.Address `json:"relayerRewardAddress"`
 }
 
+type GetFeeInfoOutput struct {
+	FeeAsset  common.Address
+	FeeAmount *big.Int
+}
+
 // ReceiveCrossChainMessageInput is the input to the ReceiveCrossChainMessage
 // in the contract deployed on the receiving chain
 type ReceiveCrossChainMessageInput struct {

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -71,7 +71,12 @@ func NewRelayer(
 	messageManagers := make(map[common.Hash]messages.MessageManager)
 	for address, config := range sourceSubnetInfo.MessageContracts {
 		addressHash := common.HexToHash(address)
-		messageManager, err := messages.NewMessageManager(logger, addressHash, config, destinationClients)
+		messageManager, err := messages.NewMessageManager(logger,
+			addressHash,
+			config,
+			destinationClients,
+			sourceSubnetInfo,
+		)
 		if err != nil {
 			logger.Error(
 				"Failed to create message manager",

--- a/vms/evm/destination_client.go
+++ b/vms/evm/destination_client.go
@@ -46,7 +46,7 @@ func NewDestinationClient(logger logging.Logger, subnetInfo config.DestinationSu
 	client, err := ethclient.Dial(subnetInfo.GetNodeRPCEndpoint())
 	if err != nil {
 		logger.Error(
-			"Failed to dial rpc endpoint",
+			"Failed to dial destination client rpc endpoint",
 			zap.Error(err),
 		)
 		return nil, err

--- a/vms/subscriber.go
+++ b/vms/subscriber.go
@@ -13,7 +13,7 @@ import (
 // Subscriber subscribes to VM events containing Warp message data
 type Subscriber interface {
 	// Subscribe registers a subscription. After Subscribe is called,
-	// log events that match [filter] are written to the channel returned
+	// matching log events should be written to the channel returned
 	// by Logs
 	Subscribe() error
 	// Logs returns the channel that the subscription writes events to


### PR DESCRIPTION
Adds Teleporter configuration option for supported fee assets. The relayer will only deliver a message if it is incentivized with a supported fee asset, or if the configured list of fee assets is empty.

In addition to that check, the main change here is adding an additional eth client in the Teleporter message manager, so that we can call getFeeInfo on the Teleporter contract. The message manager constructor takes the source subnet configuration to do so.