### PR TITLE
remove slashes from tag-prefix

### DIFF
--- a/relayer/.goreleaser.yml
+++ b/relayer/.goreleaser.yml
@@ -2,7 +2,7 @@
 project_name: icm-relayer
 version: 2
 monorepo:
-  tag_prefix: icm-relayer/
+  tag_prefix: icm-relayer-
 builds:
   - id: icm-relayer
     main: ./relayer/main/main.go

--- a/signature-aggregator/.goreleaser.yml
+++ b/signature-aggregator/.goreleaser.yml
@@ -2,7 +2,7 @@
 project_name: signature-aggregator
 version: 2
 monorepo:
-  tag_prefix: signature-aggregator/
+  tag_prefix: signature-aggregator-
 builds:
   - id: signature-aggregator
     main: ./signature-aggregator/main/main.go


### PR DESCRIPTION
## Why this should be merged

`go get` installation doesn't work with slashes in tag names. 

## How this works

## How this was tested

## How is this documented