### PR TITLE
move setting to unhealthy after retries

### DIFF
--- a/relayer/listener.go
+++ b/relayer/listener.go
@@ -204,8 +204,6 @@ func (lstnr *Listener) processLogs(ctx context.Context) error {
 				zap.String("sourceBlockchainID", lstnr.sourceBlockchain.GetBlockchainID().String()),
 				zap.Error(err),
 			)
-			// TODO try to resubscribe in perpetuity once we have a mechanism for refreshing state
-			// variables such as Quorum values and processing missed blocks.
 			err = lstnr.reconnectToSubscriber()
 			if err != nil {
 				lstnr.healthStatus.Store(false)

--- a/relayer/listener.go
+++ b/relayer/listener.go
@@ -199,7 +199,6 @@ func (lstnr *Listener) processLogs(ctx context.Context) error {
 				errChan,
 			)
 		case err := <-lstnr.Subscriber.Err():
-			lstnr.healthStatus.Store(false)
 			lstnr.logger.Error(
 				"Received error from subscribed node",
 				zap.String("sourceBlockchainID", lstnr.sourceBlockchain.GetBlockchainID().String()),
@@ -209,6 +208,7 @@ func (lstnr *Listener) processLogs(ctx context.Context) error {
 			// variables such as Quorum values and processing missed blocks.
 			err = lstnr.reconnectToSubscriber()
 			if err != nil {
+				lstnr.healthStatus.Store(false)
 				lstnr.logger.Error(
 					"Relayer goroutine exiting.",
 					zap.String("sourceBlockchainID", lstnr.sourceBlockchain.GetBlockchainID().String()),


### PR DESCRIPTION
## Why this should be merged

Currently the healthcheck fatals immediately on failure. This means that for intermittent connection failures this leads to a race between the reconnect setting the status back to healthy before the healthcheck is called again. If the healthcheck is called before the reconnect then the process shuts down. 

Alternative and potentially cleaner approach would be to not have the healthcheck failure shut down the process but let the kubernetes or whatever manages the process to shut it down based on the failed check and additional conditions/thresholds. 

## How this works
Doesn't set the status to unhealthy until the reconnect attempts have failed. 

## How this was tested

## How is this documented