### PR TITLE
Remove slashes from the tag-prefix for GH action trigger

### DIFF
--- a/.github/workflows/release_icm_relayer.yml
+++ b/.github/workflows/release_icm_relayer.yml
@@ -6,7 +6,7 @@ name: Release icm-relayer
 on:
   push:
     tags:
-      - "icm-relayer/*"
+      - "icm-relayer-*"
 
 jobs:
   release:

--- a/.github/workflows/release_signature_aggregator.yml
+++ b/.github/workflows/release_signature_aggregator.yml
@@ -6,7 +6,7 @@ name: Release signature-aggregator
 on:
   push:
     tags:
-      - "signature-aggregator/*"
+      - "signature-aggregator-*"
 
 jobs:
   release:


### PR DESCRIPTION
## Why this should be merged
#575 removed them from the goreleaser prefix but GH actions still trigger off of tags with slashes. this fixes it.
## How this works

## How this was tested

## How is this documented