### PR TITLE
Etna release prep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.10
 
 require (
 	github.com/alexliesenfeld/health v0.8.0
-	github.com/ava-labs/avalanchego v1.12.0-initial-poc.9.0.20241122192639-7c3ad181c928
+	github.com/ava-labs/avalanchego v1.12.1-0.20241210035517-714dfa0c3942
 	github.com/ava-labs/coreth v0.13.9-rc.1
 	github.com/ava-labs/icm-contracts v1.0.8
 	github.com/ava-labs/subnet-evm v0.6.12

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ava-labs/avalanchego v1.12.1-0.20241210035517-714dfa0c3942
 	github.com/ava-labs/coreth v0.13.9-rc.1
 	github.com/ava-labs/icm-contracts v1.0.8
-	github.com/ava-labs/subnet-evm v0.6.12
+	github.com/ava-labs/subnet-evm v0.6.13-0.20241205165027-6c98da796f35
 	github.com/aws/aws-sdk-go-v2 v1.32.6
 	github.com/aws/aws-sdk-go-v2/config v1.28.6
 	github.com/aws/aws-sdk-go-v2/service/kms v1.37.7

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alexliesenfeld/health v0.8.0
 	github.com/ava-labs/avalanchego v1.12.1-0.20241210035517-714dfa0c3942
 	github.com/ava-labs/coreth v0.13.9-rc.1
-	github.com/ava-labs/icm-contracts v1.0.8
+	github.com/ava-labs/icm-contracts v1.0.9-0.20241210131047-74f89f0f9331
 	github.com/ava-labs/subnet-evm v0.6.13-0.20241205165027-6c98da796f35
 	github.com/aws/aws-sdk-go-v2 v1.32.6
 	github.com/aws/aws-sdk-go-v2/config v1.28.6

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/ava-labs/coreth v0.13.9-rc.1 h1:qIICpC/OZGYUP37QnLgIqqwGmxnLwLpZaUlqJ
 github.com/ava-labs/coreth v0.13.9-rc.1/go.mod h1:7aMsRIo/3GBE44qWZMjnfqdqfcfZ5yShTTm2LObLaYo=
 github.com/ava-labs/icm-contracts v1.0.8 h1:xS2B23WRBnG4MGSmEiy9Wp6781/wtprct9HEHrHcAic=
 github.com/ava-labs/icm-contracts v1.0.8/go.mod h1:DRu0hfN9uDyxfL0tgJBVq9OM3uc+t53KiyRov9n+OG4=
-github.com/ava-labs/subnet-evm v0.6.12 h1:jL3FmjdFcNfS0qwbehwN6DkAg9y7zexB1riiGBxRsM0=
-github.com/ava-labs/subnet-evm v0.6.12/go.mod h1:vffwL4UqAh7ibpWjveUuUhamm3a9w75q92bG5vXdX5k=
+github.com/ava-labs/subnet-evm v0.6.13-0.20241205165027-6c98da796f35 h1:CbXWon0fwGDEDCCiChx2VeIIwO3UML9+8OUTyNwPsxA=
+github.com/ava-labs/subnet-evm v0.6.13-0.20241205165027-6c98da796f35/go.mod h1:SfAF4jjYPkezKWShPY/T31WQdD/UHrDyqy0kxA0LE0w=
 github.com/aws/aws-sdk-go-v2 v1.32.6 h1:7BokKRgRPuGmKkFMhEg/jSul+tB9VvXhcViILtfG8b4=
 github.com/aws/aws-sdk-go-v2 v1.32.6/go.mod h1:P5WJBrYqqbWVaOxgH0X/FYYD47/nooaPOZPlQdmiN2U=
 github.com/aws/aws-sdk-go-v2/config v1.28.6 h1:D89IKtGrs/I3QXOLNTH93NJYtDhm8SYa9Q5CsPShmyo=

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/avalanchego v1.12.0-initial-poc.9.0.20241122192639-7c3ad181c928 h1:th+K+wWgAYL/NsrFJyO+/sThLRdEDE0+I4vgbPLoWQQ=
-github.com/ava-labs/avalanchego v1.12.0-initial-poc.9.0.20241122192639-7c3ad181c928/go.mod h1:yhD5dpZyStIVbxQ550EDi5w5SL7DQ/xGE6TIxosb7U0=
+github.com/ava-labs/avalanchego v1.12.1-0.20241210035517-714dfa0c3942 h1:eDSWDIaaMHNEAorxQqnA88S39zlgmQ26OKgWn5AaDJ0=
+github.com/ava-labs/avalanchego v1.12.1-0.20241210035517-714dfa0c3942/go.mod h1:yhD5dpZyStIVbxQ550EDi5w5SL7DQ/xGE6TIxosb7U0=
 github.com/ava-labs/awm-relayer v1.4.1-0.20241122202209-75359d908260 h1:VRNzoY1xvXHphcXXmuXMrUFp5Gm/eiipVJMmNV+UN9c=
 github.com/ava-labs/awm-relayer v1.4.1-0.20241122202209-75359d908260/go.mod h1:/hrQpd8P3BfShbRoDE1vD1WZXBchu7r8CQPTEb5tWOQ=
 github.com/ava-labs/coreth v0.13.9-rc.1 h1:qIICpC/OZGYUP37QnLgIqqwGmxnLwLpZaUlqJNI85vU=

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/ava-labs/coreth v0.13.9-rc.1 h1:qIICpC/OZGYUP37QnLgIqqwGmxnLwLpZaUlqJ
 github.com/ava-labs/coreth v0.13.9-rc.1/go.mod h1:7aMsRIo/3GBE44qWZMjnfqdqfcfZ5yShTTm2LObLaYo=
 github.com/ava-labs/icm-contracts v1.0.8 h1:xS2B23WRBnG4MGSmEiy9Wp6781/wtprct9HEHrHcAic=
 github.com/ava-labs/icm-contracts v1.0.8/go.mod h1:DRu0hfN9uDyxfL0tgJBVq9OM3uc+t53KiyRov9n+OG4=
+github.com/ava-labs/icm-contracts v1.0.9-0.20241210131047-74f89f0f9331 h1:Mcml40d0O2ebfVgd7wFN6X3YIAOw3j5TrR7onHP1EpY=
+github.com/ava-labs/icm-contracts v1.0.9-0.20241210131047-74f89f0f9331/go.mod h1:qYbpPBuMoWW8btWiuFPFS1uZtc2wRcUOP42DKT4M/oQ=
 github.com/ava-labs/subnet-evm v0.6.13-0.20241205165027-6c98da796f35 h1:CbXWon0fwGDEDCCiChx2VeIIwO3UML9+8OUTyNwPsxA=
 github.com/ava-labs/subnet-evm v0.6.13-0.20241205165027-6c98da796f35/go.mod h1:SfAF4jjYPkezKWShPY/T31WQdD/UHrDyqy0kxA0LE0w=
 github.com/aws/aws-sdk-go-v2 v1.32.6 h1:7BokKRgRPuGmKkFMhEg/jSul+tB9VvXhcViILtfG8b4=

--- a/peers/app_request_network.go
+++ b/peers/app_request_network.go
@@ -127,13 +127,21 @@ func NewNetwork(
 	validatorClient := validators.NewCanonicalValidatorClient(logger, cfg.GetPChainAPI())
 	manager := snowVdrs.NewManager()
 
+	networkMetrics := prometheus.NewRegistry()
 	testNetworkConfig, err := network.NewTestNetworkConfig(
-		registerer,
+		networkMetrics,
 		networkID,
 		manager,
 		trackedSubnets,
 	)
-	testNetwork, err := network.NewTestNetwork(logger, registerer, testNetworkConfig, handler)
+	if err != nil {
+		logger.Error(
+			"Failed to create test network config",
+			zap.Error(err),
+		)
+		return nil, err
+	}
+	testNetwork, err := network.NewTestNetwork(logger, networkMetrics, testNetworkConfig, handler)
 	if err != nil {
 		logger.Error(
 			"Failed to create test network",

--- a/peers/app_request_network.go
+++ b/peers/app_request_network.go
@@ -127,7 +127,13 @@ func NewNetwork(
 	validatorClient := validators.NewCanonicalValidatorClient(logger, cfg.GetPChainAPI())
 	manager := snowVdrs.NewManager()
 
-	testNetwork, err := network.NewTestNetwork(logger, networkID, manager, trackedSubnets, handler)
+	testNetworkConfig, err := network.NewTestNetworkConfig(
+		registerer,
+		networkID,
+		manager,
+		trackedSubnets,
+	)
+	testNetwork, err := network.NewTestNetwork(logger, registerer, testNetworkConfig, handler)
 	if err != nil {
 		logger.Error(
 			"Failed to create test network",

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -19,10 +19,12 @@ export GO_VERSION=${GO_VERSION:-$(getDepVersion go)}
 # Don't export them as they're used in the context of other calls
 AVALANCHEGO_VERSION=${AVALANCHEGO_VERSION:-$(getDepVersion github.com/ava-labs/avalanchego)}
 # Temporarily hardcode the Avalanchego version until outbound networking relaxation is available
-AVALANCHEGO_VERSION=v1.12.0-fuji
+AVALANCHEGO_VERSION=v1.12.0
 GINKGO_VERSION=${GINKGO_VERSION:-$(getDepVersion github.com/onsi/ginkgo/v2)}
 
 SUBNET_EVM_VERSION=${SUBNET_EVM_VERSION:-$(getDepVersion github.com/ava-labs/subnet-evm)}
+# Temporarily harcode the Subnet EVM version until there is a tagged release
+SUBNET_EVM_VERSION=6c98da796f359335f2dcfd1151af191584be8d74
 
 # Set golangci-lint version
 GOLANGCI_LINT_VERSION=${GOLANGCI_LINT_VERSION:-'v1.60'}

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/icm-contracts/tests/network"
 	teleporterTestUtils "github.com/ava-labs/icm-contracts/tests/utils"
@@ -143,7 +144,9 @@ var _ = ginkgo.BeforeSuite(func() {
 	// Restart the network to attempt to refresh TLS connections
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(60*len(localNetworkInstance.Nodes))*time.Second)
 	defer cancel()
-	err = localNetworkInstance.Restart(ctx, os.Stdout)
+
+	logger := logging.NewLogger("tmpnet")
+	err = localNetworkInstance.Restart(ctx, logger)
 	Expect(err).Should(BeNil())
 
 	decider = exec.CommandContext(ctx, "./tests/cmd/decider/decider")


### PR DESCRIPTION
## Why this should be merged
Updates avago, subnet-evm and teleporter->icm-contracts. Avago and subnet point to commits in master (no tags yet). 

`icm-contracts` points to a commit on a branch due to circular dependency for now. 
It does not include the private IP network change. This is going to be added in #580

## How this works

## How this was tested

## How is this documented