### PR TITLE
Reduce retries

### DIFF
--- a/signature-aggregator/aggregator/aggregator_test.go
+++ b/signature-aggregator/aggregator/aggregator_test.go
@@ -218,7 +218,7 @@ func TestCreateSignedMessageRetriesAndFailsWithoutP2PResponses(t *testing.T) {
 	appRequests := makeAppRequests(chainID, requestID, connectedValidators)
 	for _, appRequest := range appRequests {
 		mockNetwork.EXPECT().RegisterAppRequest(appRequest).Times(
-			maxRelayerQueryAttempts,
+			maxQueryAttempts,
 		)
 	}
 
@@ -227,7 +227,7 @@ func TestCreateSignedMessageRetriesAndFailsWithoutP2PResponses(t *testing.T) {
 		len(appRequests),
 	).Return(
 		make(chan message.InboundMessage, len(appRequests)),
-	).Times(maxRelayerQueryAttempts)
+	).Times(maxQueryAttempts)
 
 	var nodeIDs set.Set[ids.NodeID]
 	for _, appRequest := range appRequests {
@@ -238,7 +238,7 @@ func TestCreateSignedMessageRetriesAndFailsWithoutP2PResponses(t *testing.T) {
 		nodeIDs,
 		subnetID,
 		subnets.NoOpAllower,
-	).Times(maxRelayerQueryAttempts)
+	).Times(maxQueryAttempts)
 
 	_, err = aggregator.CreateSignedMessage(msg, nil, subnetID, 80)
 	require.ErrorIs(


### PR DESCRIPTION
## Why this should be merged
Improves UX by reducing the total time to get a response when unable to send requests to nodes (due to P2P peer discovery) and returns a more meaningful message instead of generic `failed to collect a threshold of signatures`

## How this works

## How this was tested
CI should pass

## How is this documented