### PR TITLE
pass a logger to NewNetwork, so as to give control on where to redirect the logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.10
 require (
 	github.com/alexliesenfeld/health v0.8.0
 	github.com/ava-labs/avalanchego v1.12.1-0.20241210172525-c7ebd8fbae88
-	github.com/ava-labs/icm-contracts v1.0.9-0.20241218145356-cd512247d9e2
+	github.com/ava-labs/icm-contracts v1.0.9-0.20241231155804-0845b3c9fd39
 	github.com/ava-labs/subnet-evm v0.6.13-0.20241205165027-6c98da796f35
 	github.com/aws/aws-sdk-go-v2 v1.32.7
 	github.com/aws/aws-sdk-go-v2/config v1.28.7

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/ava-labs/avalanchego v1.12.1-0.20241210172525-c7ebd8fbae88 h1:tZdtOPF
 github.com/ava-labs/avalanchego v1.12.1-0.20241210172525-c7ebd8fbae88/go.mod h1:yhD5dpZyStIVbxQ550EDi5w5SL7DQ/xGE6TIxosb7U0=
 github.com/ava-labs/coreth v0.13.9-rc.1 h1:qIICpC/OZGYUP37QnLgIqqwGmxnLwLpZaUlqJNI85vU=
 github.com/ava-labs/coreth v0.13.9-rc.1/go.mod h1:7aMsRIo/3GBE44qWZMjnfqdqfcfZ5yShTTm2LObLaYo=
-github.com/ava-labs/icm-contracts v1.0.9-0.20241218145356-cd512247d9e2 h1:4wxAk748u1jaBTaY7qSsCRsNAhLno4h2XqMbwNnowRg=
-github.com/ava-labs/icm-contracts v1.0.9-0.20241218145356-cd512247d9e2/go.mod h1:1cCh1DTmorvDRwyBxOSbnhp9JtcRh+j8OdawBCvZTzA=
+github.com/ava-labs/icm-contracts v1.0.9-0.20241231155804-0845b3c9fd39 h1:gDvyXiHtyGHL2TfyYz48gybEOfsapI3PBXY148EJ2h8=
+github.com/ava-labs/icm-contracts v1.0.9-0.20241231155804-0845b3c9fd39/go.mod h1:hZS72/9tbM+9JKdTs/UuGIWF3z+FEVlcGW4B9C8gECs=
 github.com/ava-labs/subnet-evm v0.6.13-0.20241205165027-6c98da796f35 h1:CbXWon0fwGDEDCCiChx2VeIIwO3UML9+8OUTyNwPsxA=
 github.com/ava-labs/subnet-evm v0.6.13-0.20241205165027-6c98da796f35/go.mod h1:SfAF4jjYPkezKWShPY/T31WQdD/UHrDyqy0kxA0LE0w=
 github.com/aws/aws-sdk-go-v2 v1.32.7 h1:ky5o35oENWi0JYWUZkB7WYvVPP+bcRF5/Iq7JWSb5Rw=

--- a/peers/app_request_network.go
+++ b/peers/app_request_network.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
@@ -76,21 +75,12 @@ type appRequestNetwork struct {
 
 // NewNetwork creates a P2P network client for interacting with validators
 func NewNetwork(
-	logLevel logging.Level,
+	logger logging.Logger,
 	registerer prometheus.Registerer,
 	trackedSubnets set.Set[ids.ID],
 	manuallyTrackedPeers []info.Peer,
 	cfg Config,
 ) (AppRequestNetwork, error) {
-	logger := logging.NewLogger(
-		"p2p-network",
-		logging.NewWrappedCore(
-			logLevel,
-			os.Stdout,
-			logging.JSON.ConsoleEncoder(),
-		),
-	)
-
 	metrics, err := newAppRequestNetworkMetrics(registerer)
 	if err != nil {
 		logger.Error("Failed to create app request network metrics", zap.Error(err))

--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -138,6 +138,14 @@ func main() {
 	if logLevel <= logging.Debug {
 		networkLogLevel = logLevel
 	}
+	networkLogger := logging.NewLogger(
+		"p2p-network",
+		logging.NewWrappedCore(
+			networkLogLevel,
+			os.Stdout,
+			logging.JSON.ConsoleEncoder(),
+		),
+	)
 
 	// Initialize message creator passed down to relayers for creating app requests.
 	// We do not collect metrics for the message creator.
@@ -163,7 +171,7 @@ func main() {
 	}
 
 	network, err := peers.NewNetwork(
-		networkLogLevel,
+		networkLogger,
 		registerer,
 		nil,
 		manuallyTrackedPeers,

--- a/signature-aggregator/main/main.go
+++ b/signature-aggregator/main/main.go
@@ -84,6 +84,14 @@ func main() {
 	if logLevel <= logging.Debug {
 		networkLogLevel = logLevel
 	}
+	networkLogger := logging.NewLogger(
+		"p2p-network",
+		logging.NewWrappedCore(
+			networkLogLevel,
+			os.Stdout,
+			logging.JSON.ConsoleEncoder(),
+		),
+	)
 
 	// Initialize message creator passed down to relayers for creating app requests.
 	// We do not collect metrics for the message creator.
@@ -99,7 +107,7 @@ func main() {
 	}
 
 	network, err := peers.NewNetwork(
-		networkLogLevel,
+		networkLogger,
 		prometheus.DefaultRegisterer,
 		nil,
 		nil,


### PR DESCRIPTION
## Why this should be merged
Currently AppRequest networks logs just go to stdout without having any option to modify this. 
This PR let the user pass in a logger so he can decide where to put them.

Note: depends on icm-contracts branch https://github.com/ava-labs/icm-contracts/tree/pass-a-logger-to-new-network to pass CI

## How this works

## How this was tested

## How is this documented