### PR TITLE
pin goreleaser to v2.5.1

### DIFF
--- a/.github/workflows/release_icm_relayer.yml
+++ b/.github/workflows/release_icm_relayer.yml
@@ -61,7 +61,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: '~> v2'
+          version: v2.5.1
           args: release --clean --config relayer/.goreleaser.yml
         env:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret

--- a/.github/workflows/release_signature_aggregator.yml
+++ b/.github/workflows/release_signature_aggregator.yml
@@ -61,7 +61,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: '~> v2'
+          version: v2.5.1
           args: release --clean --config signature-aggregator/.goreleaser.yml
         env:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret


### PR DESCRIPTION
## Why this should be merged
Last build failed with a clang arg error and this goreleaser version is a suspect as mentioned here: https://github.com/ava-labs/subnet-evm/pull/1439
## How this works

## How this was tested

## How is this documented