### PR TITLE
Reduce noisy logs

### DIFF
--- a/peers/app_request_network.go
+++ b/peers/app_request_network.go
@@ -259,6 +259,7 @@ func (n *appRequestNetwork) startUpdateValidators() {
 		// Fetch validators immediately when called, and refresh every ValidatorRefreshPeriod
 		ticker := time.NewTicker(ValidatorRefreshPeriod)
 		for ; true; <-ticker.C {
+			n.logger.Debug("Fetching validators for subnets", zap.Any("subnetIDs", append([]ids.ID{constants.PrimaryNetworkID}, n.trackedSubnets.List()...)))
 			n.updateValidatorSet(context.Background(), constants.PrimaryNetworkID)
 			for _, subnet := range n.trackedSubnets.List() {
 				n.updateValidatorSet(context.Background(), subnet)
@@ -273,8 +274,6 @@ func (n *appRequestNetwork) updateValidatorSet(
 ) error {
 	n.lock.Lock()
 	defer n.lock.Unlock()
-
-	n.logger.Debug("Fetching validators for subnet ID", zap.Stringer("subnetID", subnetID))
 
 	// Fetch the subnet validators from the P-Chain
 	validators, err := n.validatorClient.GetProposedValidators(ctx, subnetID)

--- a/relayer/application_relayer.go
+++ b/relayer/application_relayer.go
@@ -142,7 +142,7 @@ func (r *ApplicationRelayer) ProcessHeight(
 	handlers []messages.MessageHandler,
 	errChan chan error,
 ) {
-	r.logger.Debug(
+	r.logger.Verbo(
 		"Processing block",
 		zap.Uint64("height", height),
 		zap.Stringer("relayerID", r.relayerID.ID),
@@ -167,7 +167,7 @@ func (r *ApplicationRelayer) ProcessHeight(
 		return
 	}
 	r.checkpointManager.StageCommittedHeight(height)
-	r.logger.Debug(
+	r.logger.Verbo(
 		"Processed block",
 		zap.Uint64("height", height),
 		zap.String("sourceBlockchainID", r.relayerID.SourceBlockchainID.String()),

--- a/relayer/checkpoint/checkpoint.go
+++ b/relayer/checkpoint/checkpoint.go
@@ -76,7 +76,7 @@ func (cm *CheckpointManager) writeToDatabase() {
 	if storedHeight >= cm.committedHeight {
 		return
 	}
-	cm.logger.Debug(
+	cm.logger.Verbo(
 		"Writing height",
 		zap.Uint64("height", cm.committedHeight),
 		zap.String("relayerID", cm.relayerID.ID.String()),
@@ -123,16 +123,16 @@ func (cm *CheckpointManager) StageCommittedHeight(height uint64) {
 	// First push the height onto the pending commits min heap
 	// This will ensure that the heights are committed in order
 	heap.Push(cm.pendingCommits, height)
-	cm.logger.Debug(
+	cm.logger.Verbo(
 		"Pending committed heights",
-		zap.Any("pendingCommits", cm.pendingCommits),
+		zap.Any("maxPendingHeight", height),
 		zap.Uint64("maxCommittedHeight", cm.committedHeight),
 		zap.String("relayerID", cm.relayerID.ID.String()),
 	)
 
 	for cm.pendingCommits.Peek() == cm.committedHeight+1 {
 		h := heap.Pop(cm.pendingCommits).(uint64)
-		cm.logger.Debug(
+		cm.logger.Verbo(
 			"Committing height",
 			zap.Uint64("height", height),
 			zap.String("relayerID", cm.relayerID.ID.String()),

--- a/relayer/message_coordinator.go
+++ b/relayer/message_coordinator.go
@@ -268,7 +268,7 @@ func (mc *MessageCoordinator) ProcessBlock(
 		// Dispatch all messages in the block to the appropriate application relayer.
 		// An empty slice is still a valid argument to ProcessHeight; in this case the height is immediately committed.
 		handlers := messageHandlers[appRelayer.relayerID.ID]
-		mc.logger.Debug(
+		mc.logger.Verbo(
 			"Dispatching to app relayer",
 			zap.Stringer("relayerID", appRelayer.relayerID.ID),
 			zap.Int("numMessages", len(handlers)),


### PR DESCRIPTION
## Why this should be merged
Reduces debug log noise by demoting some logs to `Verbo` and consolidating others. These changes reduce the hourly logs produced at `Debug` log level from ~45k to ~100.
