### PR TITLE
Empty app response handling

### DIFF
--- a/signature-aggregator/aggregator/aggregator.go
+++ b/signature-aggregator/aggregator/aggregator.go
@@ -48,6 +48,7 @@ var (
 	// Errors
 	errNotEnoughSignatures     = errors.New("failed to collect a threshold of signatures")
 	errNotEnoughConnectedStake = errors.New("failed to connect to a threshold of stake")
+	errEmptyResponseBytes      = errors.New("received empty app response bytes")
 )
 
 type SignatureAggregator struct {
@@ -547,7 +548,9 @@ func (s *SignatureAggregator) isValidSignatureResponse(
 		return blsSignatureBuf{}, false
 	}
 
-	signature, err := s.unmarshalResponse(appResponse.AppBytes)
+	appResponse.GetAppBytes()
+
+	signature, err := s.unmarshalResponse(appResponse.GetAppBytes())
 	if err != nil {
 		s.logger.Error(
 			"Error unmarshaling signature response",
@@ -644,6 +647,9 @@ func (s *SignatureAggregator) marshalRequest(
 }
 
 func (s *SignatureAggregator) unmarshalResponse(responseBytes []byte) (blsSignatureBuf, error) {
+	if len(responseBytes) == 0 {
+		return blsSignatureBuf{}, errEmptyResponseBytes
+	}
 	var sigResponse sdk.SignatureResponse
 	err := proto.Unmarshal(responseBytes, &sigResponse)
 	if err != nil {

--- a/signature-aggregator/aggregator/aggregator.go
+++ b/signature-aggregator/aggregator/aggregator.go
@@ -644,7 +644,8 @@ func (s *SignatureAggregator) marshalRequest(
 }
 
 func (s *SignatureAggregator) unmarshalResponse(responseBytes []byte) (blsSignatureBuf, error) {
-	if len(responseBytes) == 0 { // empty responses are valid and indicate the node has not seen the message
+	// empty responses are valid and indicate the node has not seen the message
+	if len(responseBytes) == 0 {
 		return blsSignatureBuf{}, nil
 	}
 	var sigResponse sdk.SignatureResponse

--- a/signature-aggregator/aggregator/aggregator.go
+++ b/signature-aggregator/aggregator/aggregator.go
@@ -48,7 +48,6 @@ var (
 	// Errors
 	errNotEnoughSignatures     = errors.New("failed to collect a threshold of signatures")
 	errNotEnoughConnectedStake = errors.New("failed to connect to a threshold of stake")
-	errEmptyResponseBytes      = errors.New("received empty app response bytes")
 )
 
 type SignatureAggregator struct {
@@ -548,8 +547,6 @@ func (s *SignatureAggregator) isValidSignatureResponse(
 		return blsSignatureBuf{}, false
 	}
 
-	appResponse.GetAppBytes()
-
 	signature, err := s.unmarshalResponse(appResponse.GetAppBytes())
 	if err != nil {
 		s.logger.Error(
@@ -647,8 +644,8 @@ func (s *SignatureAggregator) marshalRequest(
 }
 
 func (s *SignatureAggregator) unmarshalResponse(responseBytes []byte) (blsSignatureBuf, error) {
-	if len(responseBytes) == 0 {
-		return blsSignatureBuf{}, errEmptyResponseBytes
+	if len(responseBytes) == 0 { // empty responses are valid and indicate the node has not seen the message
+		return blsSignatureBuf{}, nil
 	}
 	var sigResponse sdk.SignatureResponse
 	err := proto.Unmarshal(responseBytes, &sigResponse)

--- a/signature-aggregator/aggregator/aggregator_test.go
+++ b/signature-aggregator/aggregator/aggregator_test.go
@@ -373,7 +373,7 @@ func TestUnmarshalResponse(t *testing.T) {
 		},
 		{
 			name:              "nil slice",
-			appResponseBytes:  []byte{},
+			appResponseBytes:  nil,
 			expectedSignature: blsSignatureBuf{},
 		},
 		{

--- a/signature-aggregator/aggregator/aggregator_test.go
+++ b/signature-aggregator/aggregator/aggregator_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"testing"
 
+	"crypto/rand"
+
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/message"
 	"github.com/ava-labs/avalanchego/proto/pb/sdk"
@@ -344,6 +346,59 @@ func TestCreateSignedMessageSucceeds(t *testing.T) {
 		100,
 	)
 	require.NoError(t, verifyErr)
+}
+
+func TestUnmarshalResponse(t *testing.T) {
+	aggregator, _ := instantiateAggregator(t)
+
+	emptySignatureResponse, err := proto.Marshal(&sdk.SignatureResponse{Signature: []byte{}})
+	require.NoError(t, err)
+
+	randSignature := make([]byte, 96)
+	_, err = rand.Read(randSignature)
+	require.NoError(t, err)
+
+	randSignatureResponse, err := proto.Marshal(&sdk.SignatureResponse{Signature: randSignature})
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name              string
+		appResponseBytes  []byte
+		expectedSignature blsSignatureBuf
+		err               error
+	}{
+		{
+			name:              "empty slice",
+			appResponseBytes:  []byte{},
+			expectedSignature: blsSignatureBuf{},
+			err:               errEmptyResponseBytes,
+		},
+		{
+			name:              "nil slice",
+			appResponseBytes:  []byte{},
+			expectedSignature: blsSignatureBuf{},
+			err:               errEmptyResponseBytes,
+		},
+		{
+			name:              "empty signature", // this is a valid signature response for nodes unable or unwilling to sign a message
+			appResponseBytes:  emptySignatureResponse,
+			expectedSignature: blsSignatureBuf{},
+			err:               errEmptyResponseBytes,
+		},
+		{
+			name:              "random signature",
+			appResponseBytes:  randSignatureResponse,
+			expectedSignature: blsSignatureBuf(randSignature),
+			err:               nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			signature, err := aggregator.unmarshalResponse(tc.appResponseBytes)
+			require.Equal(t, tc.err, err)
+			require.Equal(t, tc.expectedSignature, signature)
+		})
+	}
 }
 
 type pChainStateStub struct {

--- a/signature-aggregator/aggregator/aggregator_test.go
+++ b/signature-aggregator/aggregator/aggregator_test.go
@@ -365,37 +365,32 @@ func TestUnmarshalResponse(t *testing.T) {
 		name              string
 		appResponseBytes  []byte
 		expectedSignature blsSignatureBuf
-		err               error
 	}{
 		{
 			name:              "empty slice",
 			appResponseBytes:  []byte{},
 			expectedSignature: blsSignatureBuf{},
-			err:               errEmptyResponseBytes,
 		},
 		{
 			name:              "nil slice",
 			appResponseBytes:  []byte{},
 			expectedSignature: blsSignatureBuf{},
-			err:               errEmptyResponseBytes,
 		},
 		{
-			name:              "empty signature", // this is a valid signature response for nodes unable or unwilling to sign a message
+			name:              "empty signature",
 			appResponseBytes:  emptySignatureResponse,
 			expectedSignature: blsSignatureBuf{},
-			err:               errEmptyResponseBytes,
 		},
 		{
 			name:              "random signature",
 			appResponseBytes:  randSignatureResponse,
 			expectedSignature: blsSignatureBuf(randSignature),
-			err:               nil,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			signature, err := aggregator.unmarshalResponse(tc.appResponseBytes)
-			require.Equal(t, tc.err, err)
+			require.NoError(t, err)
 			require.Equal(t, tc.expectedSignature, signature)
 		})
 	}


### PR DESCRIPTION
## Why this should be merged
Fixes a bug in handling empty SignatureResponses. This was introduced with ACP-118 support since the SignatureResponse only has a single Signature field with `omitempty` tag, meaning that the empty signature serializes to empty slice. 

Trying to unmarshal an empty slices however results in a runtime panic. 

## How this works

## How this was tested
E2E + added new unit test for `aggregator.unmarshalResponse`

## How is this documented