### PR TITLE
Put the right handler in the right place

### DIFF
--- a/relayer/api/relay_message.go
+++ b/relayer/api/relay_message.go
@@ -39,11 +39,11 @@ type ManualWarpMessageRequest struct {
 }
 
 func HandleRelayMessage(logger logging.Logger, messageCoordinator *relayer.MessageCoordinator) {
-	http.Handle(RelayAPIPath, relayAPIHandler(logger, messageCoordinator))
+	http.Handle(RelayMessageAPIPath, relayMessageAPIHandler(logger, messageCoordinator))
 }
 
 func HandleRelay(logger logging.Logger, messageCoordinator *relayer.MessageCoordinator) {
-	http.Handle(RelayMessageAPIPath, relayMessageAPIHandler(logger, messageCoordinator))
+	http.Handle(RelayAPIPath, relayAPIHandler(logger, messageCoordinator))
 }
 
 func relayMessageAPIHandler(logger logging.Logger, messageCoordinator *relayer.MessageCoordinator) http.Handler {


### PR DESCRIPTION
## Why this should be merged

The actual change makes no difference because both handlers are being used with the same `MessageCoordinator` instance. If we were to change things up, it would be really confusing as to why this was not working as expected

## How this works

## How this was tested

## How is this documented
