### PR TITLE
Fix configuration link in signature-aggregator docs

### DIFF
--- a/signature-aggregator/README.md
+++ b/signature-aggregator/README.md
@@ -10,7 +10,7 @@ To build the application run `scripts/build_signature_aggregator.sh` which will 
 ## Running
 
 To run the binary you must supply a config file via `./signature-aggregator --config-file`
-Currently required configurations are a small subset of the [`icm-relayer` configuration](https://github.com/ava-labs/icm-services?tab=readme-ov-file#configuration).
+Currently required configurations are a small subset of the [`icm-relayer` configuration](https://github.com/ava-labs/icm-services/blob/main/relayer/README.md#configuration).
 
 Namely:
 - `LogLevel`: string


### PR DESCRIPTION
## Why this should be merged

The docs must have moved so the link was broken

## How this works

## How this was tested

## How is this documented
