### PR TITLE
Implement LRU tracking of subnets

### DIFF
--- a/peers/app_request_network.go
+++ b/peers/app_request_network.go
@@ -24,6 +24,7 @@ import (
 	vdrs "github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/subnets"
 	"github.com/ava-labs/avalanchego/utils/constants"
+	"github.com/ava-labs/avalanchego/utils/linked"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/sampler"
 	"github.com/ava-labs/avalanchego/utils/set"
@@ -43,14 +44,15 @@ const (
 	InboundMessageChannelSize = 1000
 	ValidatorRefreshPeriod    = time.Second * 5
 	NumBootstrapNodes         = 5
-	// corresponds to maxNumTrackedSubnets is defined in avalanchego peers package
-	// TODO: export this value on the avago side so it can be used here.
-	maxTrackedSubnets = 16
+	// Maximum number of subnets that can be tracked by the app request network
+	// This value is defined in avalanchego peers package
+	// TODO: use the avalanchego constant when it is exported
+	maxNumSubnets = 16
 )
 
 var (
 	ErrNotEnoughConnectedStake = errors.New("failed to connect to a threshold of stake")
-	errTrackingTooManySubnets  = fmt.Errorf("cannot track more than %d subnets", maxTrackedSubnets)
+	errTrackingTooManySubnets  = fmt.Errorf("cannot track more than %d subnets", maxNumSubnets)
 )
 
 type AppRequestNetwork interface {
@@ -79,12 +81,16 @@ type appRequestNetwork struct {
 	handler         *RelayerExternalHandler
 	infoAPI         *InfoAPI
 	logger          logging.Logger
-	lock            *sync.RWMutex
+	lock            *sync.Mutex
 	validatorClient validators.CanonicalValidatorState
 	metrics         *AppRequestNetworkMetrics
 
 	trackedSubnets set.Set[ids.ID]
-	manager        vdrs.Manager
+	// invariant: members of lruSubnets should always be exactly the same as trackedSubnets
+	// and the size of lruSubnets should be less than or equal to maxNumSubnets
+	lruSubnets *linked.Hashmap[ids.ID, interface{}]
+
+	manager vdrs.Manager
 }
 
 // NewNetwork creates a P2P network client for interacting with validators
@@ -135,7 +141,7 @@ func NewNetwork(
 
 	// Primary network must not be explicitly tracked so removing it prior to creating TestNetworkConfig
 	trackedSubnets.Remove(constants.PrimaryNetworkID)
-	if trackedSubnets.Len() > maxTrackedSubnets {
+	if trackedSubnets.Len() > maxNumSubnets {
 		return nil, errTrackingTooManySubnets
 	}
 	testNetworkConfig, err := network.NewTestNetworkConfig(
@@ -228,17 +234,22 @@ func NewNetwork(
 	go logger.RecoverAndPanic(func() {
 		testNetwork.Dispatch()
 	})
+	lruSubnets := linked.NewHashmapWithSize[ids.ID, interface{}](maxNumSubnets)
+	for _, subnetID := range trackedSubnets.List() {
+		lruSubnets.Put(subnetID, nil)
+	}
 
 	arNetwork := &appRequestNetwork{
 		network:         testNetwork,
 		handler:         handler,
 		infoAPI:         infoAPI,
 		logger:          logger,
-		lock:            new(sync.RWMutex),
+		lock:            new(sync.Mutex),
 		validatorClient: validatorClient,
 		metrics:         metrics,
 		trackedSubnets:  trackedSubnets,
 		manager:         manager,
+		lruSubnets:      lruSubnets,
 	}
 
 	arNetwork.startUpdateValidators()
@@ -246,22 +257,33 @@ func NewNetwork(
 	return arNetwork, nil
 }
 
-// Helper to scope read lock acquisition
-func (n *appRequestNetwork) containsSubnet(subnetID ids.ID) bool {
-	n.lock.RLock()
-	defer n.lock.RUnlock()
-	return n.trackedSubnets.Contains(subnetID)
+// Helper to scope lock acquisition
+func (n *appRequestNetwork) trackSubnet(subnetID ids.ID) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	if n.trackedSubnets.Contains(subnetID) {
+		// update the access to keep it in the LRU
+		n.lruSubnets.Put(subnetID, nil)
+		return
+	}
+	if n.lruSubnets.Len() >= maxNumSubnets {
+		oldestSubnetID, _, _ := n.lruSubnets.Oldest()
+		if !n.trackedSubnets.Contains(oldestSubnetID) {
+			panic(fmt.Sprintf("SubnetID present in LRU but not in trackedSubnets: %s", oldestSubnetID))
+		}
+		n.trackedSubnets.Remove(oldestSubnetID)
+		n.lruSubnets.Delete(oldestSubnetID)
+		n.logger.Info("Removing LRU subnetID from tracked subnets", zap.Stringer("subnetID", oldestSubnetID))
+	}
+	n.logger.Info("Tracking subnet", zap.Stringer("subnetID", subnetID))
+	n.lruSubnets.Put(subnetID, nil)
+	n.trackedSubnets.Add(subnetID)
 }
 
 // TrackSubnet adds the subnet to the list of tracked subnets
 // and initiates the connections to the subnet's validators asynchronously
 func (n *appRequestNetwork) TrackSubnet(subnetID ids.ID) {
-	if n.containsSubnet(subnetID) {
-		return
-	}
-
-	n.logger.Debug("Tracking subnet", zap.Stringer("subnetID", subnetID))
-	n.trackedSubnets.Add(subnetID)
+	n.trackSubnet(subnetID)
 	n.updateValidatorSet(context.Background(), subnetID)
 }
 

--- a/peers/app_request_network_test.go
+++ b/peers/app_request_network_test.go
@@ -4,12 +4,16 @@
 package peers
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/peer"
+	snowVdrs "github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
+	"github.com/ava-labs/avalanchego/utils/linked"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
@@ -19,6 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
+
+var metrics, _ = newAppRequestNetworkMetrics(prometheus.DefaultRegisterer)
 
 func TestCalculateConnectedWeight(t *testing.T) {
 	vdr1 := makeValidator(t, 10, 1)
@@ -62,7 +68,6 @@ func TestConnectToCanonicalValidators(t *testing.T) {
 	validator1_1 := makeValidator(t, 1, 1)
 	validator2_1 := makeValidator(t, 2, 1)
 	validator3_2 := makeValidator(t, 3, 2)
-	metrics, _ := newAppRequestNetworkMetrics(prometheus.DefaultRegisterer)
 
 	testCases := []struct {
 		name                    string
@@ -159,6 +164,51 @@ func TestConnectToCanonicalValidators(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestTrackSubnets(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockNetwork := avago_mocks.NewMockNetwork(ctrl)
+	mockValidatorClient := validator_mocks.NewMockCanonicalValidatorState(ctrl)
+	arNetwork := appRequestNetwork{
+		network:         mockNetwork,
+		logger:          logging.NoLog{},
+		validatorClient: mockValidatorClient,
+		metrics:         metrics,
+		manager:         snowVdrs.NewManager(),
+		lruSubnets:      linked.NewHashmapWithSize[ids.ID, interface{}](maxNumSubnets),
+		lock:            new(sync.Mutex),
+	}
+	require.Zero(t, arNetwork.trackedSubnets.Len())
+	require.Zero(t, arNetwork.lruSubnets.Len())
+	mockValidatorClient.EXPECT().GetProposedValidators(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	for range maxNumSubnets {
+		arNetwork.TrackSubnet(ids.GenerateTestID())
+	}
+	require.Equal(t, arNetwork.trackedSubnets.Len(), arNetwork.lruSubnets.Len())
+	require.Equal(t, arNetwork.trackedSubnets.Len(), maxNumSubnets)
+
+	// Add one more subnet, which should evict the oldest subnet
+	newSubnetID := ids.GenerateTestID()
+	oldestSubnetID, _, ok := arNetwork.lruSubnets.Oldest()
+	require.True(t, ok)
+	arNetwork.TrackSubnet(newSubnetID)
+	require.Equal(t, maxNumSubnets, arNetwork.trackedSubnets.Len())
+	require.Equal(t, maxNumSubnets, arNetwork.lruSubnets.Len())
+	require.False(t, arNetwork.trackedSubnets.Contains(oldestSubnetID))
+	_, has := arNetwork.lruSubnets.Get(oldestSubnetID)
+	require.False(t, has)
+
+	it := arNetwork.lruSubnets.NewIterator()
+	require.NotNil(t, it)
+	for range maxNumSubnets {
+		require.True(t, it.Next())
+		subnetID := it.Key()
+		// confirm that they are still in sync
+		require.True(t, arNetwork.trackedSubnets.Contains(subnetID))
+	}
+	// confirm that the iterator is exhausted after maxNumSubnets iterations
+	require.False(t, it.Next())
 }
 
 func makeValidator(t *testing.T, weight uint64, numNodeIDs int) warp.Validator {


### PR DESCRIPTION
## Why this should be merged

Only track up to maxNumberSubnets at any given point 

## How this works

use a `linked.Hashmap` to implement the LRU cache. 

## How this was tested
New unit test + CI

## How is this documented