### PR TITLE
Set fortuna upgrade time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ out/
 
 # Release build outputs
 osxcross/
+
+# Local DB
+.icm-relayer-storage/

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.6
 
 require (
 	github.com/alexliesenfeld/health v0.8.0
-	github.com/ava-labs/avalanchego v1.13.1-0.20250324225627-486823637d34 // branch icm-services-patch-v1.13.0
+	github.com/ava-labs/avalanchego v1.13.1-0.20250326010016-044f93f83526 // branch icm-services-patch-v1.13.0
 	github.com/ava-labs/icm-contracts v1.0.9-0.20250307173936-f6a36b902f4f
 	github.com/ava-labs/subnet-evm v0.7.2
 	github.com/aws/aws-sdk-go-v2 v1.36.3

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/avalanchego v1.13.1-0.20250324225627-486823637d34 h1:ytaybTqpkow2XgTuXsURe2rfFEepip776RNcOaaYNaU=
-github.com/ava-labs/avalanchego v1.13.1-0.20250324225627-486823637d34/go.mod h1:fpV/GmbfIB3P53gkq6zFpyeQtyAsJIuZCCKnm7TJ4sQ=
+github.com/ava-labs/avalanchego v1.13.1-0.20250326010016-044f93f83526 h1:SfanfD6LKFujnsVGnEa3vfqIXpCVLVh7ZYbcfqcAF+w=
+github.com/ava-labs/avalanchego v1.13.1-0.20250326010016-044f93f83526/go.mod h1:fpV/GmbfIB3P53gkq6zFpyeQtyAsJIuZCCKnm7TJ4sQ=
 github.com/ava-labs/coreth v0.15.0-rc.0 h1:wabaNbSXcqhhO6Qg/9fnrgDNCuP3StwB5sls45dHbiI=
 github.com/ava-labs/coreth v0.15.0-rc.0/go.mod h1:gIGr+5WDNX1DrFvUMy53AtTpkxlM/8cNOD/PDIChKfM=
 github.com/ava-labs/icm-contracts v1.0.9-0.20250307173936-f6a36b902f4f h1:VdYGud8dYi8OOca2IeTjGI9o0S+sjYO0e/DrWw0p6RA=

--- a/relayer/network_utils.go
+++ b/relayer/network_utils.go
@@ -91,6 +91,14 @@ func checkSufficientConnectedStake(
 			connectedValidators.ValidatorSet.TotalWeight,
 			maxQuorumNumerator,
 		) {
+			logger.Info(
+				"Connected to sufficient stake",
+				zap.Stringer("subnetID", subnetID),
+				zap.Uint64("quorumNumerator", maxQuorumNumerator),
+				zap.Uint64("connectedWeight", connectedValidators.ConnectedWeight),
+				zap.Uint64("totalValidatorWeight", connectedValidators.ValidatorSet.TotalWeight),
+				zap.Int("numConnectedPeers", network.NumConnectedPeers()),
+			)
 			return nil
 		}
 		logger.Warn(
@@ -99,6 +107,7 @@ func checkSufficientConnectedStake(
 			zap.Uint64("quorumNumerator", maxQuorumNumerator),
 			zap.Uint64("connectedWeight", connectedValidators.ConnectedWeight),
 			zap.Uint64("totalValidatorWeight", connectedValidators.ValidatorSet.TotalWeight),
+			zap.Int("numConnectedPeers", network.NumConnectedPeers()),
 		)
 		return fmt.Errorf("failed to connect to sufficient stake")
 	}


### PR DESCRIPTION
## Why this should be merged
The peer handshake logic requires that connecting peers have similar minor versions starting at the activation time for the network upgrade corresponding to that minor version. We use `TestNetwork`, which instead hardcodes this compatibiliity time to 0, meaning that peers must _always_ have similar minor versions.

This is an issue when rolling out network upgrade versions to peers ahead of the activation time. During that window, a relayer using the upgrade version will be unwilling to connect to peers that have not yet upgraded, even though the network upgrade has not yet occurred.

## How this works

Updates the Avalanchego custom dependency branch to add a `minCompatibilityTime` to the `NewTestNetwork` constructor, and adds logic to set this time to the Fortuna activation time for the corresponding network. We will need to update this with every subsequent network activation time as they become available.

## How this was tested
Local testing, CI

## How is this documented
N/A