### PR TITLE
Handler refactor to deduplicate logging

### DIFF
--- a/messages/message_handler.go
+++ b/messages/message_handler.go
@@ -17,33 +17,37 @@ import (
 // for each message protocol, and performs the sending to the destination chain.
 type MessageHandlerFactory interface {
 	// Create a message handler to relay the Warp message
-	NewMessageHandler(unsignedMessage *warp.UnsignedMessage) (MessageHandler, error)
+	NewMessageHandler(
+		unsignedMessage *warp.UnsignedMessage,
+		destinationClient vms.DestinationClient,
+	) (MessageHandler, error)
+
+	// Return info for routing the message to the correct relayer
+	GetMessageRoutingInfo(unsignedMessage *warp.UnsignedMessage) (MessageRoutingInfo, error)
+}
+
+// Struct containing fields for routing messages to the correct relayer.
+type MessageRoutingInfo struct {
+	SourceChainID      ids.ID
+	SenderAddress      common.Address
+	DestinationChainID ids.ID
+	DestinationAddress common.Address
 }
 
 // MessageHandlers relay a single Warp message. A new instance should be created for each Warp message.
 type MessageHandler interface {
 	// ShouldSendMessage returns true if the message should be sent to the destination chain
 	// If an error is returned, the boolean should be ignored by the caller.
-	ShouldSendMessage(destinationClient vms.DestinationClient) (bool, error)
+	ShouldSendMessage() (bool, error)
 
 	// SendMessage sends the signed message to the destination chain. The payload parsed according to
 	// the VM rules is also passed in, since MessageManager does not assume any particular VM
 	// returns the transaction hash if the transaction is successful.
-	SendMessage(signedMessage *warp.Message, destinationClient vms.DestinationClient) (common.Hash, error)
+	SendMessage(signedMessage *warp.Message) (common.Hash, error)
 
 	// GetLogContext returns extra fields to be set in the logger
 	// when passing it along to the signature aggregator
 	GetLogContext() []zap.Field
-
-	// GetMessageRoutingInfo returns the source chain ID, origin sender address,
-	// destination chain ID, and destination address.
-	GetMessageRoutingInfo() (
-		ids.ID,
-		common.Address,
-		ids.ID,
-		common.Address,
-		error,
-	)
 
 	// GetUnsignedMessage returns the unsigned message
 	GetUnsignedMessage() *warp.UnsignedMessage

--- a/messages/mocks/mock_message_handler.go
+++ b/messages/mocks/mock_message_handler.go
@@ -12,7 +12,6 @@ package mocks
 import (
 	reflect "reflect"
 
-	ids "github.com/ava-labs/avalanchego/ids"
 	warp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	messages "github.com/ava-labs/icm-services/messages"
 	vms "github.com/ava-labs/icm-services/vms"
@@ -45,19 +44,34 @@ func (m *MockMessageHandlerFactory) EXPECT() *MockMessageHandlerFactoryMockRecor
 	return m.recorder
 }
 
-// NewMessageHandler mocks base method.
-func (m *MockMessageHandlerFactory) NewMessageHandler(unsignedMessage *warp.UnsignedMessage) (messages.MessageHandler, error) {
+// GetMessageRoutingInfo mocks base method.
+func (m *MockMessageHandlerFactory) GetMessageRoutingInfo(unsignedMessage *warp.UnsignedMessage) (messages.MessageRoutingInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewMessageHandler", unsignedMessage)
+	ret := m.ctrl.Call(m, "GetMessageRoutingInfo", unsignedMessage)
+	ret0, _ := ret[0].(messages.MessageRoutingInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMessageRoutingInfo indicates an expected call of GetMessageRoutingInfo.
+func (mr *MockMessageHandlerFactoryMockRecorder) GetMessageRoutingInfo(unsignedMessage any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMessageRoutingInfo", reflect.TypeOf((*MockMessageHandlerFactory)(nil).GetMessageRoutingInfo), unsignedMessage)
+}
+
+// NewMessageHandler mocks base method.
+func (m *MockMessageHandlerFactory) NewMessageHandler(unsignedMessage *warp.UnsignedMessage, destinationClient vms.DestinationClient) (messages.MessageHandler, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewMessageHandler", unsignedMessage, destinationClient)
 	ret0, _ := ret[0].(messages.MessageHandler)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewMessageHandler indicates an expected call of NewMessageHandler.
-func (mr *MockMessageHandlerFactoryMockRecorder) NewMessageHandler(unsignedMessage any) *gomock.Call {
+func (mr *MockMessageHandlerFactoryMockRecorder) NewMessageHandler(unsignedMessage, destinationClient any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMessageHandler", reflect.TypeOf((*MockMessageHandlerFactory)(nil).NewMessageHandler), unsignedMessage)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMessageHandler", reflect.TypeOf((*MockMessageHandlerFactory)(nil).NewMessageHandler), unsignedMessage, destinationClient)
 }
 
 // MockMessageHandler is a mock of MessageHandler interface.
@@ -98,24 +112,6 @@ func (mr *MockMessageHandlerMockRecorder) GetLogContext() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogContext", reflect.TypeOf((*MockMessageHandler)(nil).GetLogContext))
 }
 
-// GetMessageRoutingInfo mocks base method.
-func (m *MockMessageHandler) GetMessageRoutingInfo() (ids.ID, common.Address, ids.ID, common.Address, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMessageRoutingInfo")
-	ret0, _ := ret[0].(ids.ID)
-	ret1, _ := ret[1].(common.Address)
-	ret2, _ := ret[2].(ids.ID)
-	ret3, _ := ret[3].(common.Address)
-	ret4, _ := ret[4].(error)
-	return ret0, ret1, ret2, ret3, ret4
-}
-
-// GetMessageRoutingInfo indicates an expected call of GetMessageRoutingInfo.
-func (mr *MockMessageHandlerMockRecorder) GetMessageRoutingInfo() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMessageRoutingInfo", reflect.TypeOf((*MockMessageHandler)(nil).GetMessageRoutingInfo))
-}
-
 // GetUnsignedMessage mocks base method.
 func (m *MockMessageHandler) GetUnsignedMessage() *warp.UnsignedMessage {
 	m.ctrl.T.Helper()
@@ -131,31 +127,31 @@ func (mr *MockMessageHandlerMockRecorder) GetUnsignedMessage() *gomock.Call {
 }
 
 // SendMessage mocks base method.
-func (m *MockMessageHandler) SendMessage(signedMessage *warp.Message, destinationClient vms.DestinationClient) (common.Hash, error) {
+func (m *MockMessageHandler) SendMessage(signedMessage *warp.Message) (common.Hash, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendMessage", signedMessage, destinationClient)
+	ret := m.ctrl.Call(m, "SendMessage", signedMessage)
 	ret0, _ := ret[0].(common.Hash)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SendMessage indicates an expected call of SendMessage.
-func (mr *MockMessageHandlerMockRecorder) SendMessage(signedMessage, destinationClient any) *gomock.Call {
+func (mr *MockMessageHandlerMockRecorder) SendMessage(signedMessage any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMessage", reflect.TypeOf((*MockMessageHandler)(nil).SendMessage), signedMessage, destinationClient)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendMessage", reflect.TypeOf((*MockMessageHandler)(nil).SendMessage), signedMessage)
 }
 
 // ShouldSendMessage mocks base method.
-func (m *MockMessageHandler) ShouldSendMessage(destinationClient vms.DestinationClient) (bool, error) {
+func (m *MockMessageHandler) ShouldSendMessage() (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ShouldSendMessage", destinationClient)
+	ret := m.ctrl.Call(m, "ShouldSendMessage")
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ShouldSendMessage indicates an expected call of ShouldSendMessage.
-func (mr *MockMessageHandlerMockRecorder) ShouldSendMessage(destinationClient any) *gomock.Call {
+func (mr *MockMessageHandlerMockRecorder) ShouldSendMessage() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldSendMessage", reflect.TypeOf((*MockMessageHandler)(nil).ShouldSendMessage), destinationClient)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldSendMessage", reflect.TypeOf((*MockMessageHandler)(nil).ShouldSendMessage))
 }

--- a/messages/off-chain-registry/message_handler.go
+++ b/messages/off-chain-registry/message_handler.go
@@ -70,7 +70,10 @@ func NewMessageHandlerFactory(
 	}, nil
 }
 
-func (f *factory) NewMessageHandler(unsignedMessage *warp.UnsignedMessage, destinationClient vms.DestinationClient) (messages.MessageHandler, error) {
+func (f *factory) NewMessageHandler(
+	unsignedMessage *warp.UnsignedMessage,
+	destinationClient vms.DestinationClient,
+) (messages.MessageHandler, error) {
 	logFields := []zap.Field{
 		zap.Stringer("warpMessageID", unsignedMessage.ID()),
 		zap.Stringer("destinationBlockchainID", destinationClient.DestinationBlockchainID()),

--- a/messages/off-chain-registry/message_handler.go
+++ b/messages/off-chain-registry/message_handler.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	warpPayload "github.com/ava-labs/avalanchego/vms/platformvm/warp/payload"
@@ -35,9 +34,11 @@ type factory struct {
 }
 
 type messageHandler struct {
-	logger          logging.Logger
-	unsignedMessage *warp.UnsignedMessage
-	factory         *factory
+	logger            logging.Logger
+	unsignedMessage   *warp.UnsignedMessage
+	destinationClient vms.DestinationClient
+	factory           *factory
+	logFields         []zap.Field
 }
 
 func NewMessageHandlerFactory(
@@ -69,12 +70,39 @@ func NewMessageHandlerFactory(
 	}, nil
 }
 
-func (f *factory) NewMessageHandler(unsignedMessage *warp.UnsignedMessage) (messages.MessageHandler, error) {
+func (f *factory) NewMessageHandler(unsignedMessage *warp.UnsignedMessage, destinationClient vms.DestinationClient) (messages.MessageHandler, error) {
+	logFields := []zap.Field{
+		zap.Stringer("warpMessageID", unsignedMessage.ID()),
+		zap.Stringer("destinationBlockchainID", destinationClient.DestinationBlockchainID()),
+	}
 	return &messageHandler{
-		logger:          f.logger,
-		unsignedMessage: unsignedMessage,
-		factory:         f,
+		logger:            f.logger.With(logFields...),
+		unsignedMessage:   unsignedMessage,
+		destinationClient: destinationClient,
+		factory:           f,
+		logFields:         logFields,
 	}, nil
+}
+
+func (f *factory) GetMessageRoutingInfo(unsignedMessage *warp.UnsignedMessage) (
+	messages.MessageRoutingInfo,
+	error,
+) {
+	addressedPayload, err := warpPayload.ParseAddressedCall(unsignedMessage.Payload)
+	if err != nil {
+		f.logger.Error(
+			"Failed parsing addressed payload",
+			zap.Error(err),
+		)
+		return messages.MessageRoutingInfo{}, err
+	}
+	return messages.MessageRoutingInfo{
+			SourceChainID:      unsignedMessage.SourceChainID,
+			SenderAddress:      common.BytesToAddress(addressedPayload.SourceAddress),
+			DestinationChainID: unsignedMessage.SourceChainID,
+			DestinationAddress: f.registryAddress,
+		},
+		nil
 }
 
 func (m *messageHandler) GetUnsignedMessage() *warp.UnsignedMessage {
@@ -84,7 +112,7 @@ func (m *messageHandler) GetUnsignedMessage() *warp.UnsignedMessage {
 // ShouldSendMessage returns false if any contract is already registered as the specified version
 // in the TeleporterRegistry contract. This is because a single contract address can be registered
 // to multiple versions, but each version may only map to a single contract address.
-func (m *messageHandler) ShouldSendMessage(destinationClient vms.DestinationClient) (bool, error) {
+func (m *messageHandler) ShouldSendMessage() (bool, error) {
 	addressedPayload, err := warpPayload.ParseAddressedCall(m.unsignedMessage.Payload)
 	if err != nil {
 		m.logger.Error(
@@ -113,11 +141,11 @@ func (m *messageHandler) ShouldSendMessage(destinationClient vms.DestinationClie
 	}
 
 	// Get the correct destination client from the global map
-	client, ok := destinationClient.Client().(ethclient.Client)
+	client, ok := m.destinationClient.Client().(ethclient.Client)
 	if !ok {
 		panic(fmt.Sprintf(
 			"Destination client for chain %s is not an Ethereum client",
-			destinationClient.DestinationBlockchainID().String()),
+			m.destinationClient.DestinationBlockchainID().String()),
 		)
 	}
 
@@ -152,24 +180,16 @@ func (m *messageHandler) ShouldSendMessage(destinationClient vms.DestinationClie
 
 func (m *messageHandler) SendMessage(
 	signedMessage *warp.Message,
-	destinationClient vms.DestinationClient,
 ) (common.Hash, error) {
 	// Construct the transaction call data to call the TeleporterRegistry contract.
 	// Only one off-chain registry Warp message is sent at a time, so we hardcode the index to 0 in the call.
 	callData, err := teleporterregistry.PackAddProtocolVersion(0)
 	if err != nil {
-		m.logger.Error(
-			"Failed packing receiveCrossChainMessage call data",
-			zap.String(
-				"destinationBlockchainID",
-				destinationClient.DestinationBlockchainID().String(),
-			),
-			zap.String("warpMessageID", signedMessage.ID().String()),
-		)
+		m.logger.Error("Failed packing receiveCrossChainMessage call data")
 		return common.Hash{}, err
 	}
 
-	txHash, err := destinationClient.SendTx(
+	txHash, err := m.destinationClient.SendTx(
 		signedMessage,
 		m.factory.registryAddress.Hex(),
 		addProtocolVersionGasLimit,
@@ -178,45 +198,14 @@ func (m *messageHandler) SendMessage(
 	if err != nil {
 		m.logger.Error(
 			"Failed to send tx.",
-			zap.String(
-				"destinationBlockchainID",
-				destinationClient.DestinationBlockchainID().String(),
-			),
-			zap.String("warpMessageID", signedMessage.ID().String()),
 			zap.Error(err),
 		)
 		return common.Hash{}, err
 	}
-	m.logger.Info(
-		"Sent message to destination chain",
-		zap.String("destinationBlockchainID", destinationClient.DestinationBlockchainID().String()),
-		zap.String("warpMessageID", signedMessage.ID().String()),
-	)
+	m.logger.Info("Sent message to destination chain")
 	return txHash, nil
 }
 
-func (m *messageHandler) GetMessageRoutingInfo() (
-	ids.ID,
-	common.Address,
-	ids.ID,
-	common.Address,
-	error,
-) {
-	addressedPayload, err := warpPayload.ParseAddressedCall(m.unsignedMessage.Payload)
-	if err != nil {
-		m.logger.Error(
-			"Failed parsing addressed payload",
-			zap.Error(err),
-		)
-		return ids.ID{}, common.Address{}, ids.ID{}, common.Address{}, err
-	}
-	return m.unsignedMessage.SourceChainID,
-		common.BytesToAddress(addressedPayload.SourceAddress),
-		m.unsignedMessage.SourceChainID,
-		m.factory.registryAddress,
-		nil
-}
-
 func (m *messageHandler) GetLogContext() []zap.Field {
-	return []zap.Field{zap.String("unsignedWarpMessageID", m.unsignedMessage.ID().String())}
+	return m.logFields
 }

--- a/messages/off-chain-registry/message_handler_test.go
+++ b/messages/off-chain-registry/message_handler_test.go
@@ -166,9 +166,9 @@ func TestShouldSendMessage(t *testing.T) {
 					test.destinationBlockchainID,
 				)
 			}
-			messageHandler, err := factory.NewMessageHandler(unsignedMessage)
+			messageHandler, err := factory.NewMessageHandler(unsignedMessage, mockClient)
 			require.NoError(t, err)
-			result, err := messageHandler.ShouldSendMessage(mockClient)
+			result, err := messageHandler.ShouldSendMessage()
 			if test.expectedError {
 				require.Error(t, err)
 			} else {

--- a/messages/teleporter/message_handler.go
+++ b/messages/teleporter/message_handler.go
@@ -92,7 +92,10 @@ func NewMessageHandlerFactory(
 	}, nil
 }
 
-func (f *factory) NewMessageHandler(unsignedMessage *warp.UnsignedMessage, destinationClient vms.DestinationClient) (messages.MessageHandler, error) {
+func (f *factory) NewMessageHandler(
+	unsignedMessage *warp.UnsignedMessage,
+	destinationClient vms.DestinationClient,
+) (messages.MessageHandler, error) {
 	teleporterMessage, err := f.parseTeleporterMessage(unsignedMessage)
 	if err != nil {
 		f.logger.Error(
@@ -111,10 +114,10 @@ func (f *factory) NewMessageHandler(unsignedMessage *warp.UnsignedMessage, desti
 	if err != nil {
 		f.logger.Error(
 			"Failed to calculate Teleporter message ID.",
-			zap.Stringer("warpMessageID", unsignedMessage.ID())
+			zap.Stringer("warpMessageID", unsignedMessage.ID()),
 			zap.Error(err),
 		)
-		return &messageHandler{}, err 
+		return &messageHandler{}, err
 	}
 
 	logFields := []zap.Field{

--- a/messages/teleporter/message_handler_test.go
+++ b/messages/teleporter/message_handler_test.go
@@ -217,7 +217,7 @@ func TestShouldSendMessage(t *testing.T) {
 				nil,
 			)
 			require.NoError(t, err)
-			messageHandler, err := factory.NewMessageHandler(test.warpUnsignedMessage)
+			messageHandler, err := factory.NewMessageHandler(test.warpUnsignedMessage, mockClient)
 			if test.expectedParseError {
 				// If we expect an error parsing the Warp message, we should not call ShouldSendMessage
 				require.Error(t, err)
@@ -248,7 +248,7 @@ func TestShouldSendMessage(t *testing.T) {
 					Times(test.messageReceivedCall.times)
 			}
 
-			result, err := messageHandler.ShouldSendMessage(mockClient)
+			result, err := messageHandler.ShouldSendMessage()
 			require.NoError(t, err)
 			require.Equal(t, test.expectedResult, result)
 		})

--- a/messages/teleporter/message_handler_test.go
+++ b/messages/teleporter/message_handler_test.go
@@ -217,6 +217,7 @@ func TestShouldSendMessage(t *testing.T) {
 				nil,
 			)
 			require.NoError(t, err)
+			mockClient.EXPECT().DestinationBlockchainID().Return(destinationBlockchainID).AnyTimes()
 			messageHandler, err := factory.NewMessageHandler(test.warpUnsignedMessage, mockClient)
 			if test.expectedParseError {
 				// If we expect an error parsing the Warp message, we should not call ShouldSendMessage
@@ -235,7 +236,6 @@ func TestShouldSendMessage(t *testing.T) {
 				Return(test.senderAddressResult).
 				Times(test.senderAddressTimes)
 			mockClient.EXPECT().BlockGasLimit().Return(uint64(blockGasLimit)).AnyTimes()
-			mockClient.EXPECT().DestinationBlockchainID().Return(destinationBlockchainID).AnyTimes()
 			if test.messageReceivedCall != nil {
 				messageReceivedInput := interfaces.CallMsg{
 					From: bind.CallOpts{}.From,

--- a/relayer/application_relayer.go
+++ b/relayer/application_relayer.go
@@ -188,7 +188,7 @@ func (r *ApplicationRelayer) ProcessMessage(handler messages.MessageHandler) (co
 		zap.String("sourceBlockchainID", r.sourceBlockchain.BlockchainID),
 		zap.String("relayerID", r.relayerID.ID.String()),
 	)
-	shouldSend, err := handler.ShouldSendMessage(r.destinationClient)
+	shouldSend, err := handler.ShouldSendMessage()
 	if err != nil {
 		r.logger.Error(
 			"Failed to check if message should be sent",
@@ -246,7 +246,7 @@ func (r *ApplicationRelayer) ProcessMessage(handler messages.MessageHandler) (co
 	// create signed message latency (ms)
 	r.setCreateSignedMessageLatencyMS(float64(time.Since(startCreateSignedMessageTime).Milliseconds()))
 
-	txHash, err := handler.SendMessage(signedMessage, r.destinationClient)
+	txHash, err := handler.SendMessage(signedMessage)
 	if err != nil {
 		r.logger.Error(
 			"Failed to send warp message",

--- a/relayer/message_coordinator.go
+++ b/relayer/message_coordinator.go
@@ -94,7 +94,10 @@ func (mc *MessageCoordinator) getAppRelayerMessageHandler(
 	if appRelayer == nil {
 		return nil, nil, nil
 	}
-	messageHandler, err := messageHandlerFactory.NewMessageHandler(warpMessageInfo.UnsignedMessage, appRelayer.destinationClient)
+	messageHandler, err := messageHandlerFactory.NewMessageHandler(
+		warpMessageInfo.UnsignedMessage,
+		appRelayer.destinationClient,
+	)
 	if err != nil {
 		mc.logger.Error("Failed to create message handler", zap.Error(err))
 		return nil, nil, err

--- a/signature-aggregator/aggregator/aggregator.go
+++ b/signature-aggregator/aggregator/aggregator.go
@@ -381,11 +381,6 @@ func (s *SignatureAggregator) CreateSignedMessage(
 		failedSendNodes := make([]ids.NodeID, 0, responsesExpected)
 		for nodeID := range vdrSet {
 			if !sentTo.Contains(nodeID) {
-				log.Debug(
-					"Failed to make async request to node",
-					zap.String("nodeID", nodeID.String()),
-					zap.Error(err),
-				)
 				responsesExpected--
 				failedSendNodes = append(failedSendNodes, nodeID)
 				s.metrics.FailuresSendingToNode.Inc()


### PR DESCRIPTION
## Why this should be merged
Don't love this but this is an attempt to clean up (?) the handler/handler factory logic in order to have all of the necessary logging information up front.

## How this works

- It moves the `GetMessageRoutingInfo` to the factory instead since it doesn't depend on any handler state
- This enables passing the destinationClient into the handler constructor and storing it in the struct
- Removes destination client from method args since now it's available up front
- Logs destinationChain, warpMessageID and subnetID withContext instead of repeating it as well as passing it into the sig-agg (with the parent branch)

## How this was tested
CI
## How is this documented