### PR TITLE
add context + timeout to GetSubnetID API calls

### DIFF
--- a/peers/app_request_network.go
+++ b/peers/app_request_network.go
@@ -65,7 +65,7 @@ type AppRequestNetwork interface {
 		*ConnectedCanonicalValidators,
 		error,
 	)
-	GetSubnetID(blockchainID ids.ID) (ids.ID, error)
+	GetSubnetID(ctx context.Context, blockchainID ids.ID) (ids.ID, error)
 	RegisterAppRequest(requestID ids.RequestID)
 	RegisterRequestID(
 		requestID uint32,
@@ -472,8 +472,8 @@ func (n *appRequestNetwork) RegisterAppRequest(requestID ids.RequestID) {
 func (n *appRequestNetwork) RegisterRequestID(requestID uint32, numExpectedResponse int) chan message.InboundMessage {
 	return n.handler.RegisterRequestID(requestID, numExpectedResponse)
 }
-func (n *appRequestNetwork) GetSubnetID(blockchainID ids.ID) (ids.ID, error) {
-	return n.validatorClient.GetSubnetID(context.Background(), blockchainID)
+func (n *appRequestNetwork) GetSubnetID(ctx context.Context, blockchainID ids.ID) (ids.ID, error) {
+	return n.validatorClient.GetSubnetID(ctx, blockchainID)
 }
 
 //

--- a/peers/mocks/mock_app_request_network.go
+++ b/peers/mocks/mock_app_request_network.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	ids "github.com/ava-labs/avalanchego/ids"
@@ -60,18 +61,18 @@ func (mr *MockAppRequestNetworkMockRecorder) GetConnectedCanonicalValidators(sub
 }
 
 // GetSubnetID mocks base method.
-func (m *MockAppRequestNetwork) GetSubnetID(blockchainID ids.ID) (ids.ID, error) {
+func (m *MockAppRequestNetwork) GetSubnetID(ctx context.Context, blockchainID ids.ID) (ids.ID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSubnetID", blockchainID)
+	ret := m.ctrl.Call(m, "GetSubnetID", ctx, blockchainID)
 	ret0, _ := ret[0].(ids.ID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSubnetID indicates an expected call of GetSubnetID.
-func (mr *MockAppRequestNetworkMockRecorder) GetSubnetID(blockchainID any) *gomock.Call {
+func (mr *MockAppRequestNetworkMockRecorder) GetSubnetID(ctx, blockchainID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetID", reflect.TypeOf((*MockAppRequestNetwork)(nil).GetSubnetID), blockchainID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetID", reflect.TypeOf((*MockAppRequestNetwork)(nil).GetSubnetID), ctx, blockchainID)
 }
 
 // NumConnectedPeers mocks base method.

--- a/signature-aggregator/aggregator/aggregator.go
+++ b/signature-aggregator/aggregator/aggregator.go
@@ -51,9 +51,6 @@ const (
 	// The minimum balance that an L1 validator must maintain in order to participate
 	// in the aggregate signature.
 	minimumL1ValidatorBalance = 2048 * units.NanoAvax
-
-	// The maximum amount of time to spend waiting for a subnet ID from the PChain
-	pChainSubnetIDTimeout = 1 * time.Second
 )
 
 var (
@@ -514,7 +511,7 @@ func (s *SignatureAggregator) getSubnetID(
 		return subnetID, nil
 	}
 	log.Info("Signing subnet not found, requesting from PChain", zap.String("blockchainID", blockchainID.String()))
-	getSubnetIDCtx, cancel := context.WithTimeout(ctx, pChainSubnetIDTimeout)
+	getSubnetIDCtx, cancel := context.WithTimeout(ctx, utils.DefaultRPCTimeout)
 	defer cancel()
 	subnetID, err := s.network.GetSubnetID(getSubnetIDCtx, blockchainID)
 	if err != nil {

--- a/signature-aggregator/aggregator/aggregator.go
+++ b/signature-aggregator/aggregator/aggregator.go
@@ -514,9 +514,9 @@ func (s *SignatureAggregator) getSubnetID(
 		return subnetID, nil
 	}
 	log.Info("Signing subnet not found, requesting from PChain", zap.String("blockchainID", blockchainID.String()))
-	ctx, cancel := context.WithTimeout(ctx, pChainSubnetIDTimeout)
+	getSubnetIDCtx, cancel := context.WithTimeout(ctx, pChainSubnetIDTimeout)
 	defer cancel()
-	subnetID, err := s.network.GetSubnetID(ctx, blockchainID)
+	subnetID, err := s.network.GetSubnetID(getSubnetIDCtx, blockchainID)
 	if err != nil {
 		return ids.ID{}, fmt.Errorf("source blockchain not found for chain ID %s", blockchainID)
 	}

--- a/signature-aggregator/aggregator/aggregator_test.go
+++ b/signature-aggregator/aggregator/aggregator_test.go
@@ -166,7 +166,7 @@ func TestCreateSignedMessageFailsWithNoValidators(t *testing.T) {
 	aggregator, mockNetwork, _ := instantiateAggregator(t)
 	msg, err := warp.NewUnsignedMessage(0, ids.Empty, []byte{})
 	require.NoError(t, err)
-	mockNetwork.EXPECT().GetSubnetID(ids.Empty).Return(ids.Empty, nil)
+	mockNetwork.EXPECT().GetSubnetID(gomock.Any(), ids.Empty).Return(ids.Empty, nil)
 	mockNetwork.EXPECT().TrackSubnet(ids.Empty)
 	mockNetwork.EXPECT().GetConnectedCanonicalValidators(ids.Empty).Return(
 		&peers.ConnectedCanonicalValidators{
@@ -186,7 +186,7 @@ func TestCreateSignedMessageFailsWithoutSufficientConnectedStake(t *testing.T) {
 	aggregator, mockNetwork, _ := instantiateAggregator(t)
 	msg, err := warp.NewUnsignedMessage(0, ids.Empty, []byte{})
 	require.NoError(t, err)
-	mockNetwork.EXPECT().GetSubnetID(ids.Empty).Return(ids.Empty, nil)
+	mockNetwork.EXPECT().GetSubnetID(gomock.Any(), ids.Empty).Return(ids.Empty, nil)
 	mockNetwork.EXPECT().TrackSubnet(ids.Empty)
 	mockNetwork.EXPECT().GetConnectedCanonicalValidators(ids.Empty).Return(
 		&peers.ConnectedCanonicalValidators{
@@ -244,7 +244,7 @@ func TestCreateSignedMessageRetriesAndFailsWithoutP2PResponses(t *testing.T) {
 	require.NoError(t, err)
 
 	subnetID := ids.GenerateTestID()
-	mockNetwork.EXPECT().GetSubnetID(chainID).Return(
+	mockNetwork.EXPECT().GetSubnetID(gomock.Any(), chainID).Return(
 		subnetID,
 		nil,
 	)
@@ -330,7 +330,7 @@ func TestCreateSignedMessageSucceeds(t *testing.T) {
 			aggregator, mockNetwork, mockPClient := instantiateAggregator(t)
 
 			subnetID := ids.GenerateTestID()
-			mockNetwork.EXPECT().GetSubnetID(chainID).Return(
+			mockNetwork.EXPECT().GetSubnetID(gomock.Any(), chainID).Return(
 				subnetID,
 				nil,
 			)


### PR DESCRIPTION
## Why this should be merged
Passes in context to the PChain API calls to GetSubnetID and rewraps it with a 1 second timeout to prevent too many hanging requests during high traffic periods. 

## How this works


## How this was tested
CI
## How is this documented