### PR TITLE
Expose network metrics

### DIFF
--- a/metrics/server.go
+++ b/metrics/server.go
@@ -12,6 +12,8 @@ import (
 	"go.uber.org/zap"
 )
 
+// Starts a metrics server on the given port and registers the provided names with the metrics gatherer.
+// Returns a map of registries, keyed by the provided names.
 func StartMetricsServer(logger logging.Logger, port uint16, names []string) (map[string]*prometheus.Registry, error) {
 	gatherer := metrics.NewPrefixGatherer()
 

--- a/metrics/server.go
+++ b/metrics/server.go
@@ -32,8 +32,10 @@ func StartMetricsServer(logger logging.Logger, port uint16, names []string) (map
 	)
 
 	go func() {
-		logger.Info("Starting metrics server...",
-			zap.Uint16("port", port))
+		logger.Info(
+			"Starting metrics server...",
+			zap.Uint16("port", port),
+		)
 		err := http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
 		if err != nil {
 			logger.Fatal("Metrics server exited with error", zap.Error(err))

--- a/metrics/server.go
+++ b/metrics/server.go
@@ -1,0 +1,43 @@
+package metrics
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/ava-labs/avalanchego/api/metrics"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.uber.org/zap"
+)
+
+func StartMetricsServer(logger logging.Logger, port uint16, names []string) (map[string]*prometheus.Registry, error) {
+	gatherer := metrics.NewPrefixGatherer()
+
+	registries := make(map[string]*prometheus.Registry, len(names))
+	for _, name := range names {
+		registry := prometheus.NewRegistry()
+		if err := gatherer.Register(name, registry); err != nil {
+			return nil, err
+		}
+		registries[name] = registry
+	}
+
+	http.Handle(
+		"/metrics",
+		promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{}),
+	)
+
+	go func() {
+		logger.Info("Starting metrics server...",
+			zap.Uint16("port", port))
+		err := http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+		if err != nil {
+			logger.Fatal("Metrics server exited with error", zap.Error(err))
+			os.Exit(1)
+		}
+	}()
+
+	return registries, nil
+}

--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -140,6 +140,10 @@ func main() {
 			peerNetworkMetricsPrefix,
 		},
 	)
+	if err != nil {
+		logger.Fatal("Failed to start metrics server", zap.Error(err))
+		panic(err)
+	}
 	relayerMetricsRegistry := registries[relayerMetricsPrefix]
 	peerNetworkMetricsRegistry := registries[peerNetworkMetricsPrefix]
 

--- a/signature-aggregator/main/main.go
+++ b/signature-aggregator/main/main.go
@@ -123,6 +123,7 @@ func main() {
 	network, err := peers.NewNetwork(
 		networkLogger,
 		prometheus.DefaultRegisterer,
+		prometheus.DefaultRegisterer,
 		cfg.GetTrackedSubnets(),
 		manuallyTrackedPeers,
 		&cfg,

--- a/signature-aggregator/metrics/metrics.go
+++ b/signature-aggregator/metrics/metrics.go
@@ -5,13 +5,8 @@ package metrics
 
 import (
 	"errors"
-	"fmt"
-	"log"
-	"net/http"
 
-	"github.com/ava-labs/avalanchego/api/metrics"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
@@ -154,38 +149,4 @@ func NewSignatureAggregatorMetrics(
 	registerer.MustRegister(m.ConnectedStakeWeightPercentage)
 
 	return &m
-}
-
-func (m *SignatureAggregatorMetrics) HandleMetricsRequest(
-	gatherer metrics.MultiGatherer,
-) {
-	http.Handle(
-		"/metrics",
-		promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{}),
-	)
-}
-
-func Initialize(port uint16) *prometheus.Registry {
-	gatherer := metrics.NewPrefixGatherer()
-	registry := prometheus.NewRegistry()
-	err := gatherer.Register("signature-aggregator", registry)
-	if err != nil {
-		panic(
-			fmt.Errorf(
-				"failed to register metrics gatherer: %w",
-				err,
-			),
-		)
-	}
-
-	http.Handle(
-		"/metrics",
-		promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{}),
-	)
-
-	go func() {
-		log.Fatalln(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
-	}()
-
-	return registry
 }


### PR DESCRIPTION
## Why this should be merged
- Registers p2p network metrics with the top-level gatherer
- Refactors the metrics server creation pattern with a shared `metrics.StartMetricsServer` that encapsulates the gatherer and server instantiation

## How this works
See above

## How this was tested
CI. Manual verification that all metrics are queryable via `/metrics`

## How is this documented
N/A