### PR TITLE
Fetch pending nonce

### DIFF
--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -186,11 +186,11 @@ func cleanup() {
 var _ = ginkgo.AfterSuite(cleanup)
 
 var _ = ginkgo.Describe("[ICM Relayer Integration Tests", func() {
-	ginkgo.It("Manually Provided Message", func() {
-		ManualMessage(localNetworkInstance, teleporterInfo)
-	})
 	ginkgo.It("Basic Relay", func() {
 		BasicRelay(localNetworkInstance, teleporterInfo)
+	})
+	ginkgo.It("Manually Provided Message", func() {
+		ManualMessage(localNetworkInstance, teleporterInfo)
 	})
 	ginkgo.It("Shared Database", func() {
 		SharedDatabaseAccess(localNetworkInstance, teleporterInfo)

--- a/vms/evm/destination_client.go
+++ b/vms/evm/destination_client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
+	"github.com/ava-labs/coreth/rpc"
 	"github.com/ava-labs/icm-services/relayer/config"
 	"github.com/ava-labs/icm-services/utils"
 	"github.com/ava-labs/icm-services/vms/evm/signer"
@@ -85,7 +86,8 @@ func NewDestinationClient(
 		return nil, err
 	}
 
-	nonce, err := client.NonceAt(context.Background(), sgnr.Address(), nil)
+	// Fetch the pending nonce for the relayer's address to account for restarts due to long-pending txs in the mempool
+	nonce, err := client.NonceAt(context.Background(), sgnr.Address(), big.NewInt(int64(rpc.PendingBlockNumber)))
 	if err != nil {
 		logger.Error(
 			"Failed to get nonce",


### PR DESCRIPTION
## Why this should be merged
Fixes #755 by fetching the pending nonce rather than the latest nonce on startup.

## How this works
Uses `rpc. PendingBlockNumber` in the call to `eth_getTransactionCount`

## How this was tested
CI

## How is this documented
N/A