### PR TITLE
configurable block acceptance timeout

### DIFF
--- a/messages/teleporter/message_handler.go
+++ b/messages/teleporter/message_handler.go
@@ -352,7 +352,7 @@ func (m *messageHandler) waitForReceipt(
 		receipt, err = destinationClient.Client().(ethclient.Client).TransactionReceipt(callCtx, txHash)
 		return err
 	}
-	err := utils.WithRetriesTimeout(m.logger, operation, destinationClient.BlockAcceptanceTimeout(), "waitForReceipt")
+	err := utils.WithRetriesTimeout(m.logger, operation, destinationClient.TxInclusionTimeout(), "waitForReceipt")
 	if err != nil {
 		m.logger.Error(
 			"Failed to get transaction receipt",

--- a/messages/teleporter/message_handler.go
+++ b/messages/teleporter/message_handler.go
@@ -29,10 +29,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-const (
-	defaultBlockAcceptanceTimeout = 30 * time.Second
-)
-
 type factory struct {
 	messageConfig   *Config
 	protocolAddress common.Address
@@ -329,12 +325,12 @@ func (m *messageHandler) waitForReceipt(
 ) error {
 	var receipt *types.Receipt
 	operation := func() (err error) {
-		callCtx, callCtxCancel := context.WithTimeout(context.Background(), defaultBlockAcceptanceTimeout)
+		callCtx, callCtxCancel := context.WithTimeout(context.Background(), utils.DefaultRPCTimeout)
 		defer callCtxCancel()
 		receipt, err = destinationClient.Client().(ethclient.Client).TransactionReceipt(callCtx, txHash)
 		return err
 	}
-	err := utils.WithRetriesTimeout(m.logger, operation, defaultBlockAcceptanceTimeout, "waitForReceipt")
+	err := utils.WithRetriesTimeout(m.logger, operation, destinationClient.BlockAcceptanceTimeout(), "waitForReceipt")
 	if err != nil {
 		m.logger.Error(
 			"Failed to get transaction receipt",

--- a/messages/teleporter/message_handler_test.go
+++ b/messages/teleporter/message_handler_test.go
@@ -6,6 +6,7 @@ package teleporter
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
@@ -326,6 +327,11 @@ func TestSendMessageAlreadyDelivered(t *testing.T) {
 		Client().
 		Return(mockEthClient).
 		Times(2)
+
+	mockClient.EXPECT().
+		TxInclusionTimeout().
+		Return(time.Second * 1).
+		Times(1)
 
 	mockClient.EXPECT().
 		SendTx(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).

--- a/relayer/README.md
+++ b/relayer/README.md
@@ -317,11 +317,11 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 
   - The maximum base fee gas price (in WEI) the relayer is willing to pay on this blockchain. If zero or left unset, the relayer will use a multiple of the current base fee estimation, and not have an explicit maximum.
 
-  `"max-priority-fee-per-gas": unsigned interger`
+  `"max-priority-fee-per-gas": unsigned integer`
 
   - The maximum priority fee per gas (in WEI) that the relayer is willing to pay to incentivize transactions being included on this blockchain. The relayer will use the current estimation of the required gas tip cap for this blockchain, up to a maximum of this configured value. Defaults to 2.5 GWEI.
 
-  `"block-acceptance-timeout-seconds": uint64`
+  `"tx-inclusion-timeout-seconds": unisgned integer`
 
   - The time in seconds to wait for a sent transaction to be included in a block when verifying transaction receipts before erroring out. If omitted, defaults to 30 seconds.
 

--- a/relayer/README.md
+++ b/relayer/README.md
@@ -309,6 +309,10 @@ The relayer is configured via a JSON file, the path to which is passed in via th
 
   - The AWS region in which the KMS key is located. Required if `kms-key-id` is provided.
 
+  `"block-acceptance-timeout-seconds": uint64`
+
+  - The time in seconds to wait for a sent transaction to be included in a block when verifying transaction receipts before erroring out. If omitted, defaults to 30 seconds.
+
 `"decider-url": string`
 
 - The URL of a service implementing the gRPC service defined by `proto/decider`, which will be queried for each message to determine whether that message should be relayed.

--- a/relayer/config/destination_blockchain.go
+++ b/relayer/config/destination_blockchain.go
@@ -16,8 +16,9 @@ import (
 const (
 	// The block gas limit that can be specified for a Teleporter message
 	// Based on the C-Chain 15_000_000 gas limit per block, with other Warp message gas overhead conservatively estimated.
-	defaultBlockGasLimit        = 12_000_000
-	defaultMaxPriorityFeePerGas = 2500000000 // 2.5 gwei
+	defaultBlockGasLimit             = 12_000_000
+	defaultMaxPriorityFeePerGas      = 2500000000 // 2.5 gwei
+	defaultTxInclusionTimeoutSeconds = 30
 )
 
 // Destination blockchain configuration. Specifies how to connect to and issue
@@ -33,8 +34,8 @@ type DestinationBlockchain struct {
 	BlockGasLimit        uint64            `mapstructure:"block-gas-limit" json:"block-gas-limit"`
 	MaxBaseFee           uint64            `mapstructure:"max-base-fee" json:"max-base-fee"`
 	MaxPriorityFeePerGas uint64            `mapstructure:"max-priority-fee-per-gas" json:"max-priority-fee-per-gas"`
-	//nolint:lll
-	BlockAcceptanceTimeoutSeconds uint64 `mapstructure:"block-acceptance-timeout-seconds" json:"block-acceptance-timeout-seconds"`
+
+	TxInclusionTimeoutSeconds uint64 `mapstructure:"tx-inclusion-timeout-seconds" json:"tx-inclusion-timeout-seconds"`
 
 	// Fetched from the chain after startup
 	warpConfig WarpConfig
@@ -93,6 +94,10 @@ func (s *DestinationBlockchain) Validate() error {
 	// will use the current base fee from the chain at the time of the transaction.
 	if s.MaxPriorityFeePerGas == 0 {
 		s.MaxPriorityFeePerGas = defaultMaxPriorityFeePerGas
+	}
+
+	if s.TxInclusionTimeoutSeconds == 0 {
+		s.TxInclusionTimeoutSeconds = defaultTxInclusionTimeoutSeconds
 	}
 
 	return nil

--- a/relayer/config/destination_blockchain.go
+++ b/relayer/config/destination_blockchain.go
@@ -30,6 +30,8 @@ type DestinationBlockchain struct {
 	KMSAWSRegion      string            `mapstructure:"kms-aws-region" json:"kms-aws-region"`
 	AccountPrivateKey string            `mapstructure:"account-private-key" json:"account-private-key"`
 	BlockGasLimit     uint64            `mapstructure:"block-gas-limit" json:"block-gas-limit"`
+	//nolint:lll
+	BlockAcceptanceTimeoutSeconds uint64 `mapstructure:"block-acceptance-timeout-seconds" json:"block-acceptance-timeout-seconds"`
 
 	// Fetched from the chain after startup
 	warpConfig WarpConfig

--- a/vms/destination_client.go
+++ b/vms/destination_client.go
@@ -39,8 +39,8 @@ type DestinationClient interface {
 	// BlockGasLimit returns destination blockchain block gas limit
 	BlockGasLimit() uint64
 
-	// BlockAcceptanceTimeout returns the timeout for waiting for a block to be accepted on the destination chain
-	BlockAcceptanceTimeout() time.Duration
+	// TxInclusionTimeout returns the timeout for waiting for a transaction to be included on the destination chain
+	TxInclusionTimeout() time.Duration
 }
 
 func NewDestinationClient(

--- a/vms/destination_client.go
+++ b/vms/destination_client.go
@@ -7,6 +7,7 @@ package vms
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
@@ -37,6 +38,9 @@ type DestinationClient interface {
 
 	// BlockGasLimit returns destination blockchain block gas limit
 	BlockGasLimit() uint64
+
+	// BlockAcceptanceTimeout returns the timeout for waiting for a block to be accepted on the destination chain
+	BlockAcceptanceTimeout() time.Duration
 }
 
 func NewDestinationClient(

--- a/vms/evm/destination_client.go
+++ b/vms/evm/destination_client.go
@@ -29,7 +29,6 @@ import (
 const (
 	// If the max base fee is not explicitly set, use 3x the current base fee estimate
 	defaultBaseFeeFactor = 3
-	DefaultBlockAcceptanceTimeout = 30 * time.Second
 )
 
 // Client interface wraps the ethclient.Client interface for mocking purposes.
@@ -49,7 +48,7 @@ type destinationClient struct {
 	maxBaseFee              *big.Int
 	maxPriorityFeePerGas    *big.Int
 	logger                  logging.Logger
-	blockAcceptanceTimeout  time.Duration
+	txInclusionTimeout      time.Duration
 }
 
 func NewDestinationClient(
@@ -108,13 +107,6 @@ func NewDestinationClient(
 		return nil, err
 	}
 
-	var blockAcceptanceTimeout time.Duration
-	if destinationBlockchain.BlockAcceptanceTimeoutSeconds > 0 {
-		blockAcceptanceTimeout = time.Duration(destinationBlockchain.BlockAcceptanceTimeoutSeconds) * time.Second
-	} else {
-		blockAcceptanceTimeout = DefaultBlockAcceptanceTimeout
-	}
-
 	logger.Info(
 		"Initialized destination client",
 		zap.String("blockchainID", destinationID.String()),
@@ -133,7 +125,7 @@ func NewDestinationClient(
 		blockGasLimit:           destinationBlockchain.BlockGasLimit,
 		maxBaseFee:              new(big.Int).SetUint64(destinationBlockchain.MaxBaseFee),
 		maxPriorityFeePerGas:    new(big.Int).SetUint64(destinationBlockchain.MaxPriorityFeePerGas),
-		blockAcceptanceTimeout:  blockAcceptanceTimeout,
+		txInclusionTimeout:      time.Duration(destinationBlockchain.TxInclusionTimeoutSeconds) * time.Second,
 	}, nil
 }
 
@@ -254,6 +246,6 @@ func (c *destinationClient) BlockGasLimit() uint64 {
 	return c.blockGasLimit
 }
 
-func (c *destinationClient) BlockAcceptanceTimeout() time.Duration {
-	return c.blockAcceptanceTimeout
+func (c *destinationClient) TxInclusionTimeout() time.Duration {
+	return c.txInclusionTimeout
 }

--- a/vms/mocks/mock_destination_client.go
+++ b/vms/mocks/mock_destination_client.go
@@ -43,20 +43,6 @@ func (m *MockDestinationClient) EXPECT() *MockDestinationClientMockRecorder {
 	return m.recorder
 }
 
-// BlockAcceptanceTimeout mocks base method.
-func (m *MockDestinationClient) BlockAcceptanceTimeout() time.Duration {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockAcceptanceTimeout")
-	ret0, _ := ret[0].(time.Duration)
-	return ret0
-}
-
-// BlockAcceptanceTimeout indicates an expected call of BlockAcceptanceTimeout.
-func (mr *MockDestinationClientMockRecorder) BlockAcceptanceTimeout() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockAcceptanceTimeout", reflect.TypeOf((*MockDestinationClient)(nil).BlockAcceptanceTimeout))
-}
-
 // BlockGasLimit mocks base method.
 func (m *MockDestinationClient) BlockGasLimit() uint64 {
 	m.ctrl.T.Helper()
@@ -126,4 +112,18 @@ func (m *MockDestinationClient) SenderAddress() common.Address {
 func (mr *MockDestinationClientMockRecorder) SenderAddress() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SenderAddress", reflect.TypeOf((*MockDestinationClient)(nil).SenderAddress))
+}
+
+// TxInclusionTimeout mocks base method.
+func (m *MockDestinationClient) TxInclusionTimeout() time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TxInclusionTimeout")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// TxInclusionTimeout indicates an expected call of TxInclusionTimeout.
+func (mr *MockDestinationClientMockRecorder) TxInclusionTimeout() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TxInclusionTimeout", reflect.TypeOf((*MockDestinationClient)(nil).TxInclusionTimeout))
 }

--- a/vms/mocks/mock_destination_client.go
+++ b/vms/mocks/mock_destination_client.go
@@ -11,6 +11,7 @@ package mocks
 
 import (
 	reflect "reflect"
+	time "time"
 
 	ids "github.com/ava-labs/avalanchego/ids"
 	warp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
@@ -40,6 +41,20 @@ func NewMockDestinationClient(ctrl *gomock.Controller) *MockDestinationClient {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDestinationClient) EXPECT() *MockDestinationClientMockRecorder {
 	return m.recorder
+}
+
+// BlockAcceptanceTimeout mocks base method.
+func (m *MockDestinationClient) BlockAcceptanceTimeout() time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BlockAcceptanceTimeout")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// BlockAcceptanceTimeout indicates an expected call of BlockAcceptanceTimeout.
+func (mr *MockDestinationClientMockRecorder) BlockAcceptanceTimeout() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockAcceptanceTimeout", reflect.TypeOf((*MockDestinationClient)(nil).BlockAcceptanceTimeout))
 }
 
 // BlockGasLimit mocks base method.


### PR DESCRIPTION
## Why this should be merged
Closes #761 
## How this works

- Adds a new configuration option for the destination clients that if not provided defaults to the existing constant of 30 seconds.
- Replaces the inner timeout on the actual call to `TransactionReceipt` with a default RPC timeout and sets the outer one to this new configurable value

## How this was tested
- Existing CI should pass
- Should probably add a test to `SendTx` but that should test cases beyond just this timeout

## How is this documented
- New field documented in the README