### PR TITLE
replace panics and fix version flag

### DIFF
--- a/scripts/build_relayer.sh
+++ b/scripts/build_relayer.sh
@@ -54,6 +54,6 @@ fi
 
 cd $RELAYER_PATH
 # Build ICM Relayer, which is run as a standalone process
-last_git_tag=$(git describe --tags --abbrev=0 2>/dev/null) || last_git_tag="v0.0.0-dev"
+last_git_tag=$(git describe --tags --match "icm-relayer*" --abbrev=0 2>/dev/null) || last_git_tag="v0.0.0-dev"
 echo "Building ICM Relayer Version: $last_git_tag at $binary_path"
 go build -ldflags "-X 'main.version=$last_git_tag'" -o "$binary_path" "main/"*.go

--- a/scripts/build_signature_aggregator.sh
+++ b/scripts/build_signature_aggregator.sh
@@ -53,6 +53,6 @@ fi
 
 cd $SIGNATURE_AGGREGATOR_PATH
 # Build ICM Relayer, which is run as a standalone process
-last_git_tag=$(git describe --tags --abbrev=0 2>/dev/null) || last_git_tag="v0.0.0-dev"
+last_git_tag=$(git describe --tags --match "signature-aggregator*" --abbrev=0 2>/dev/null) || last_git_tag="v0.0.0-dev"
 echo "Building Signature Aggregator Version: $last_git_tag at $binary_path"
 go build -ldflags "-X 'main.version=$last_git_tag'" -o "$binary_path" "main/"*.go


### PR DESCRIPTION
## Why this should be merged
Closes #778 
## How this works
-- replaces panics during config parsing with calls to `log.Fatalf` which is equivalent to `printLn` and followed by `os.Exit(1)`. 
- fixes calls to --version flag by changing the `const` to a `var` in both `main.go` files and modifies the build scripts to match the correct prefix to override it. 
## How this was tested

Tested manually that output is human readable and works correctly and that the version flag works as intended. 

## How is this documented