### PR TITLE
N-09 Unused Keys

### DIFF
--- a/relayer/config/keys.go
+++ b/relayer/config/keys.go
@@ -11,18 +11,12 @@ const (
 
 	// Top-level configuration keys
 	LogLevelKey                        = "log-level"
-	PChainAPIKey                       = "p-chain-api"
-	InfoAPIKey                         = "info-api"
 	APIPortKey                         = "api-port"
 	MetricsPortKey                     = "metrics-port"
-	SourceBlockchainsKey               = "source-blockchains"
-	DestinationBlockchainsKey          = "destination-blockchains"
 	AccountPrivateKeyKey               = "account-private-key"
 	AccountPrivateKeysKey              = "account-private-keys-list"
 	StorageLocationKey                 = "storage-location"
-	RedisURLKey                        = "redis-url"
 	ProcessMissedBlocksKey             = "process-missed-blocks"
-	ManualWarpMessagesKey              = "manual-warp-messages"
 	DBWriteIntervalSecondsKey          = "db-write-interval-seconds"
 	SignatureCacheSizeKey              = "signature-cache-size"
 	InitialConnectionTimeoutSecondsKey = "initial-connection-timeout-seconds"

--- a/signature-aggregator/config/keys.go
+++ b/signature-aggregator/config/keys.go
@@ -11,8 +11,6 @@ const (
 
 	// Top-level configuration keys
 	LogLevelKey           = "log-level"
-	PChainAPIKey          = "p-chain-api"
-	InfoAPIKey            = "info-api"
 	APIPortKey            = "api-port"
 	MetricsPortKey        = "metrics-port"
 	SignatureCacheSizeKey = "signature-cache-size"


### PR DESCRIPTION
## Why this should be merged
Both the relayer and the signature-aggregator include configuration keys that are declared but
never actually consumed by the application, which risks misleading developers into believing
certain features exist or are configurable.

In the relayer’s config/keys.go:
  - PChainAPIKey
  - InfoAPIKey
  - SourceBlockchainsKey
  - DestinationBlockchainsKey
  - RedisURLKey
  - ManualWarpMessagesKey
In the signature-aggregator’s config/keys.go:
  - PChainAPIKey
  - InfoAPIKey

To improve code maintainability and prevent potential confusion, consider removing the
constant definitions for any configuration keys that are not currently implemented or used by
the application.

## How this works

## How this was tested

## How is this documented