### PR TITLE
N-05 Misleading Comment

### DIFF
--- a/signature-aggregator/aggregator/aggregator.go
+++ b/signature-aggregator/aggregator/aggregator.go
@@ -290,9 +290,7 @@ func (s *SignatureAggregator) CreateSignedMessage(
 		for i, validator := range connectedValidators.ValidatorSet.Validators {
 			exclude := true
 			for _, nodeID := range validator.NodeIDs {
-				// This check will pass if either
-				// 1) the node is an L1 validator with insufficient balance or
-				// 2) the node is a non-L1 (legacy) validator
+				// Filter out L1 validators that do not have minimumL1ValidatorBalance
 				if !underfundedNodes.Contains(nodeID) {
 					exclude = false
 					break


### PR DESCRIPTION
## Why this should be merged
In the CreateSignedMessage function, a critical piece of logic is designed to filter out L1 validators that do not meet a specified balance threshold. However, the comment describing this logic is misleading and does not accurately represent the operation being performed. The [comment](https://github.com/ava-labs/icm-services/blob/11c6cafa6d5a8572a2f48364e850491db5c86b80/signature-aggregator/aggregator/aggregator.go#L268-L270) explaining a key part of this logic is misleading by stating:

> // This check will pass if either
> // 1) the node is an L1 validator with insufficient balance or
> // 2) the node is a non-L1 (legacy) validator

However, the opposite check is performed: the if statement evaluates to true if the node ID is not contained in the set of underfunded nodes. 

Consider revising the comment to reflect the code logic. Implementing this correction will enhance code readability and maintainability by providing a clear and accurate explanation of the logic being applied.

## How this works

## How this was tested

## How is this documented