### PR TITLE
N-04 Code Simplification Suggestions

### DIFF
--- a/relayer/checkpoint/checkpoint.go
+++ b/relayer/checkpoint/checkpoint.go
@@ -5,6 +5,7 @@ package checkpoint
 
 import (
 	"container/heap"
+	"fmt"
 	"math"
 	"strconv"
 	"sync"
@@ -37,7 +38,7 @@ func NewCheckpointManager(
 	writeSignal chan struct{},
 	relayerID database.RelayerID,
 	startingHeight uint64,
-) *CheckpointManager {
+) (*CheckpointManager, error) {
 	h := &utils.UInt64Heap{}
 	heap.Init(h)
 	logger.Info(
@@ -53,7 +54,7 @@ func NewCheckpointManager(
 			zap.Error(err),
 			zap.String("relayerID", relayerID.ID.String()),
 		)
-		return nil
+		return nil, fmt.Errorf("failed to get the latest processed block height: %v", err)
 	}
 
 	committedHeight := math.Max(float64(storedHeight), float64(startingHeight))
@@ -66,7 +67,7 @@ func NewCheckpointManager(
 		committedHeight: uint64(committedHeight),
 		lock:            &sync.RWMutex{},
 		pendingCommits:  h,
-	}
+	}, nil
 }
 
 func (cm *CheckpointManager) Run() {

--- a/relayer/checkpoint/checkpoint.go
+++ b/relayer/checkpoint/checkpoint.go
@@ -66,6 +66,7 @@ func NewCheckpointManager(
 		committedHeight: committedHeight,
 		lock:            &sync.RWMutex{},
 		pendingCommits:  h,
+		dirty:           true,
 	}, nil
 }
 

--- a/relayer/checkpoint/checkpoint_test.go
+++ b/relayer/checkpoint/checkpoint_test.go
@@ -2,6 +2,7 @@ package checkpoint
 
 import (
 	"container/heap"
+	"strconv"
 	"testing"
 
 	"github.com/ava-labs/avalanchego/utils/logging"
@@ -59,6 +60,7 @@ func TestCommitHeight(t *testing.T) {
 		},
 	}
 	db := mock_database.NewMockRelayerDatabase(gomock.NewController(t))
+	db.EXPECT().Get(gomock.Any(), gomock.Any()).Return([]byte(strconv.FormatUint(0, 10)), nil).AnyTimes()
 	for _, test := range testCases {
 		id := database.RelayerID{
 			ID: common.BytesToHash(crypto.Keccak256([]byte(test.name))),

--- a/relayer/checkpoint/checkpoint_test.go
+++ b/relayer/checkpoint/checkpoint_test.go
@@ -65,7 +65,8 @@ func TestCommitHeight(t *testing.T) {
 		id := database.RelayerID{
 			ID: common.BytesToHash(crypto.Keccak256([]byte(test.name))),
 		}
-		cm := NewCheckpointManager(logging.NoLog{}, db, nil, id, test.currentMaxHeight)
+		cm, err := NewCheckpointManager(logging.NoLog{}, db, nil, id, test.currentMaxHeight)
+		require.NoError(t, err)
 		heap.Init(test.pendingHeights)
 		cm.pendingCommits = test.pendingHeights
 		cm.committedHeight = test.currentMaxHeight

--- a/relayer/config/config.go
+++ b/relayer/config/config.go
@@ -253,15 +253,7 @@ func (c *Config) initializeTrackedSubnets() error {
 		c.trackedSubnets.Add(sourceBlockchain.GetSubnetID())
 	}
 	for _, destinationBlockchain := range c.DestinationBlockchains {
-		warpCfg, err := c.GetWarpConfig(destinationBlockchain.GetBlockchainID())
-		if err != nil {
-			return fmt.Errorf(
-				"failed to get warp config for destination blockchain %s: %w",
-				destinationBlockchain.GetBlockchainID(),
-				err,
-			)
-		}
-		if !warpCfg.RequirePrimaryNetworkSigners {
+		if !destinationBlockchain.warpConfig.RequirePrimaryNetworkSigners {
 			c.trackedSubnets.Add(destinationBlockchain.GetSubnetID())
 		}
 	}

--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"runtime"
 
 	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/ids"
@@ -212,6 +211,7 @@ func main() {
 		)
 		os.Exit(1)
 	}
+	defer deciderConnection.Close()
 
 	messageHandlerFactories, err := createMessageHandlerFactories(
 		logger,
@@ -599,11 +599,6 @@ func createDeciderConnection(url string) (*grpc.ClientConn, error) {
 			err,
 		)
 	}
-
-	runtime.SetFinalizer(
-		connection,
-		func(c *grpc.ClientConn) { c.Close() },
-	)
 
 	return connection, nil
 }

--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -535,13 +535,21 @@ func createApplicationRelayersForSourceChain(
 			}
 		}
 
-		checkpointManager := checkpoint.NewCheckpointManager(
+		checkpointManager, err := checkpoint.NewCheckpointManager(
 			logger,
 			db,
 			ticker.Subscribe(),
 			relayerID,
 			height,
 		)
+		if err != nil {
+			logger.Error(
+				"Failed to create checkpoint manager",
+				zap.String("relayerID", relayerID.ID.String()),
+				zap.Error(err),
+			)
+			return nil, 0, err
+		}
 
 		applicationRelayer, err := relayer.NewApplicationRelayer(
 			logger,

--- a/signature-aggregator/aggregator/aggregator.go
+++ b/signature-aggregator/aggregator/aggregator.go
@@ -532,7 +532,6 @@ func (s *SignatureAggregator) CreateSignedMessage(
 			"Failed to collect a threshold of signatures",
 			zap.Uint64("accumulatedWeight", accumulatedSignatureWeight.Uint64()),
 			zap.String("sourceBlockchainID", unsignedMessage.SourceChainID.String()),
-			zap.Uint64("accumulatedWeight", accumulatedSignatureWeight.Uint64()),
 			zap.Uint64("totalValidatorWeight", connectedValidators.ValidatorSet.TotalWeight),
 			zap.Error(err),
 		)

--- a/signature-aggregator/api/api.go
+++ b/signature-aggregator/api/api.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -115,7 +114,7 @@ func signatureAggregationAPIHandler(
 		}
 		var decodedMessage []byte
 		decodedMessage, err = hex.DecodeString(
-			strings.TrimPrefix(req.Message, "0x"),
+			utils.SanitizeHexString(req.Message),
 		)
 		if err != nil {
 			msg := "Could not decode message"


### PR DESCRIPTION
## Why this should be merged
Throughout the codebase, multiple opportunities for code simplification were identified. These recommendations span various components and functionalities, addressing both specific code segments and broader architectural patterns:
  - Within the [initializeTrackedSubnets](https://github.com/ava-labs/icm-services/blob/11c6cafa6d5a8572a2f48364e850491db5c86b80/relayer/config/config.go#L248) function, the warp configuration per destination chain can be accessed through `destinationBlockchain.warpConfig` instead of through the 1GetWarpConfig` function.
  - The `req.Message` could be sanitized with [SanitizeHexString](https://github.com/ava-labs/icm-services/blob/11c6cafa6d5a8572a2f48364e850491db5c86b80/utils/utils.go#L129), just like `req.Justification`.
  - The [accumulatedSignatureWeight](https://github.com/ava-labs/icm-services/blob/11c6cafa6d5a8572a2f48364e850491db5c86b80/signature-aggregator/aggregator/aggregator.go#L501) value is emitted twice in the warning.
  - In the relayer's `main.go`, the decider connection could be closed on `defer` instead of [setting a finalizer](https://github.com/ava-labs/icm-services/blob/11c6cafa6d5a8572a2f48364e850491db5c86b80/relayer/main/main.go#L596).
  - Every time `writeToDatabase` is invoked, the [database is read](https://github.com/ava-labs/icm-services/blob/11c6cafa6d5a8572a2f48364e850491db5c86b80/relayer/checkpoint/checkpoint.go#L67-L78) to check whether the committed height exceeds the stored height. This repeated check can be avoided by moving this logic into the `NewCheckpointManager` function by setting `committedHeight` to the bigger value of `startingHeight` and `storedHeight`.

## How this works

## How this was tested

## How is this documented