### PR TITLE
N-10 Inadequate Cache Size Validation in Signature Aggregationadd limit to number of signatures

### DIFF
--- a/signature-aggregator/aggregator/cache.go
+++ b/signature-aggregator/aggregator/cache.go
@@ -48,6 +48,10 @@ func (c *SignatureCache) Add(
 		sigs map[PublicKeyBytes]SignatureBytes
 		ok   bool
 	)
+
+	// The number of signatures cached per message is implicitly bounded 
+	// by the number of validators registered on-chain.
+	// As a result, uncontrolled memory growth is not a concern.
 	if sigs, ok = c.Get(msgID); !ok {
 		sigs = make(map[PublicKeyBytes]SignatureBytes)
 	}

--- a/signature-aggregator/aggregator/cache.go
+++ b/signature-aggregator/aggregator/cache.go
@@ -49,7 +49,7 @@ func (c *SignatureCache) Add(
 		ok   bool
 	)
 
-	// The number of signatures cached per message is implicitly bounded 
+	// The number of signatures cached per message is implicitly bounded
 	// by the number of validators registered on-chain.
 	// As a result, uncontrolled memory growth is not a concern.
 	if sigs, ok = c.Get(msgID); !ok {


### PR DESCRIPTION
## Why this should be merged
The [NewSignatureCache](https://github.com/ava-labs/icm-services/blob/11c6cafa6d5a8572a2f48364e850491db5c86b80/signature-aggregator/aggregator/cache.go#L24) function in the signature aggregator component is designed to initialize a cache for storing signatures. It takes a `size` parameter that limits the number of distinct message IDs (keys) that can be held in the cache at a time. This check is crucial for preventing the cache from growing indefinitely, which could lead to memory exhaustion issues.

The check in the constructor only constrains the number of keys in the cache, but it places nolimit on the size of the values. The value associated with each key is a `map[PublicKeyBytes]SignatureBytes`. The [Add](https://github.com/ava-labs/icm-services/blob/11c6cafa6d5a8572a2f48364e850491db5c86b80/signature-aggregator/aggregator/cache.go#L42) function's logic retrieves this map and adds a new signature to it. If an attacker repeatedly sends signatures for the same, valid `msgID` but with different public keys, the underlying map of signatures for that single `msgID` will grow without any bounds, contradictory to the intention of the cache.

As of now, the set of valid public keys is constrained by the on-chain validator set such that the above is not a severe concern. However, if a future code path were to call `Add` with more arbitrary public keys, uncontrolled memory growth and a service crash is possible.

Consider introducing a safeguard within the `Add` method to enforce a reasonable limit on the number of signatures that can be stored per message ID. This change would make the memory constraints of `SignatureCache` explicit and self-contained, thereby helping prevent potential memory exhaustion scenarios, and future-proof the system.

## How this works

## How this was tested

## How is this documented