### PR TITLE
N-03 Mismanagement of Context in API Calls Hinders Responsiveness

### DIFF
--- a/peers/app_request_network.go
+++ b/peers/app_request_network.go
@@ -65,7 +65,7 @@ var (
 )
 
 type AppRequestNetwork interface {
-	GetConnectedCanonicalValidators(subnetID ids.ID, skipCache bool) (
+	GetConnectedCanonicalValidators(ctx context.Context, subnetID ids.ID, skipCache bool) (
 		*ConnectedCanonicalValidators,
 		error,
 	)
@@ -421,13 +421,14 @@ func (c *ConnectedCanonicalValidators) GetValidator(nodeID ids.NodeID) (*warp.Va
 // GetConnectedCanonicalValidators returns the validator information in canonical ordering for the given subnet
 // at the time of the call, as well as the total weight of the validators that this network is connected to
 func (n *appRequestNetwork) GetConnectedCanonicalValidators(
+	ctx context.Context,
 	subnetID ids.ID,
 	skipCache bool,
 ) (*ConnectedCanonicalValidators, error) {
 	// Get the subnet's current canonical validator set
 	fetchVdrsFunc := func(subnetID ids.ID) (avalancheWarp.CanonicalValidatorSet, error) {
 		startPChainAPICall := time.Now()
-		validatorSet, err := n.validatorClient.GetCurrentCanonicalValidatorSet(subnetID)
+		validatorSet, err := n.validatorClient.GetCurrentCanonicalValidatorSet(ctx, subnetID)
 		n.setPChainAPICallLatencyMS(float64(time.Since(startPChainAPICall).Milliseconds()))
 		return validatorSet, err
 	}
@@ -500,9 +501,9 @@ func (n *appRequestNetwork) setPChainAPICallLatencyMS(latency float64) {
 // Non-receiver util functions
 
 func GetNetworkHealthFunc(network AppRequestNetwork, subnetIDs []ids.ID) func(context.Context) error {
-	return func(context.Context) error {
+	return func(ctx context.Context) error {
 		for _, subnetID := range subnetIDs {
-			connectedValidators, err := network.GetConnectedCanonicalValidators(subnetID, false)
+			connectedValidators, err := network.GetConnectedCanonicalValidators(ctx, subnetID, false)
 			if err != nil {
 				return fmt.Errorf(
 					"failed to get connected validators: %s, %w", subnetID, err)

--- a/peers/app_request_network_test.go
+++ b/peers/app_request_network_test.go
@@ -4,6 +4,7 @@
 package peers
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -145,7 +146,7 @@ func TestConnectToCanonicalValidators(t *testing.T) {
 			for _, vdr := range testCase.validators {
 				totalWeight += vdr.Weight
 			}
-			mockValidatorClient.EXPECT().GetCurrentCanonicalValidatorSet(subnetID).Return(
+			mockValidatorClient.EXPECT().GetCurrentCanonicalValidatorSet(gomock.Any(), subnetID).Return(
 				avalancheWarp.CanonicalValidatorSet{
 					Validators:  testCase.validators,
 					TotalWeight: testCase.expectedTotalWeight,
@@ -161,7 +162,7 @@ func TestConnectToCanonicalValidators(t *testing.T) {
 			}
 			mockNetwork.EXPECT().PeerInfo(gomock.Any()).Return(peerInfo).Times(1)
 
-			ret, err := arNetwork.GetConnectedCanonicalValidators(subnetID, false)
+			ret, err := arNetwork.GetConnectedCanonicalValidators(context.Background(), subnetID, false)
 			require.Equal(t, testCase.expectedConnectedWeight, ret.ConnectedWeight)
 			require.Equal(t, testCase.expectedTotalWeight, ret.ValidatorSet.TotalWeight)
 			require.NoError(t, err)

--- a/peers/mocks/mock_app_request_network.go
+++ b/peers/mocks/mock_app_request_network.go
@@ -46,18 +46,18 @@ func (m *MockAppRequestNetwork) EXPECT() *MockAppRequestNetworkMockRecorder {
 }
 
 // GetConnectedCanonicalValidators mocks base method.
-func (m *MockAppRequestNetwork) GetConnectedCanonicalValidators(subnetID ids.ID, skipCache bool) (*peers.ConnectedCanonicalValidators, error) {
+func (m *MockAppRequestNetwork) GetConnectedCanonicalValidators(ctx context.Context, subnetID ids.ID, skipCache bool) (*peers.ConnectedCanonicalValidators, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetConnectedCanonicalValidators", subnetID, skipCache)
+	ret := m.ctrl.Call(m, "GetConnectedCanonicalValidators", ctx, subnetID, skipCache)
 	ret0, _ := ret[0].(*peers.ConnectedCanonicalValidators)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetConnectedCanonicalValidators indicates an expected call of GetConnectedCanonicalValidators.
-func (mr *MockAppRequestNetworkMockRecorder) GetConnectedCanonicalValidators(subnetID, skipCache any) *gomock.Call {
+func (mr *MockAppRequestNetworkMockRecorder) GetConnectedCanonicalValidators(ctx, subnetID, skipCache any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectedCanonicalValidators", reflect.TypeOf((*MockAppRequestNetwork)(nil).GetConnectedCanonicalValidators), subnetID, skipCache)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectedCanonicalValidators", reflect.TypeOf((*MockAppRequestNetwork)(nil).GetConnectedCanonicalValidators), ctx, subnetID, skipCache)
 }
 
 // GetSubnetID mocks base method.

--- a/peers/validators/canonical_validator_client.go
+++ b/peers/validators/canonical_validator_client.go
@@ -16,7 +16,6 @@ import (
 	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	"github.com/ava-labs/icm-services/config"
 	"github.com/ava-labs/icm-services/peers/utils"
-	sharedUtils "github.com/ava-labs/icm-services/utils"
 	"go.uber.org/zap"
 
 	pchainapi "github.com/ava-labs/avalanchego/vms/platformvm/api"
@@ -29,7 +28,7 @@ var _ CanonicalValidatorState = &CanonicalValidatorClient{}
 type CanonicalValidatorState interface {
 	validators.State
 
-	GetCurrentCanonicalValidatorSet(subnetID ids.ID) (avalancheWarp.CanonicalValidatorSet, error)
+	GetCurrentCanonicalValidatorSet(ctx context.Context, subnetID ids.ID) (avalancheWarp.CanonicalValidatorSet, error)
 	GetProposedValidators(ctx context.Context, subnetID ids.ID) (map[ids.NodeID]*validators.GetValidatorOutput, error)
 }
 
@@ -51,11 +50,12 @@ func NewCanonicalValidatorClient(logger logging.Logger, apiConfig *config.APICon
 }
 
 func (v *CanonicalValidatorClient) GetCurrentCanonicalValidatorSet(
+	ctx context.Context,
 	subnetID ids.ID,
 ) (avalancheWarp.CanonicalValidatorSet, error) {
-	// Get the current canonical validator set of the source subnet.
-	ctx, cancel := context.WithTimeout(context.Background(), sharedUtils.DefaultRPCTimeout)
-	defer cancel()
+	// // Get the current canonical validator set of the source subnet.
+	// ctx, cancel := context.WithTimeout(context.Background(), sharedUtils.DefaultRPCTimeout)
+	// defer cancel()
 	canonicalSubnetValidators, err := avalancheWarp.GetCanonicalValidatorSetFromSubnetID(
 		ctx,
 		v,

--- a/peers/validators/canonical_validator_client.go
+++ b/peers/validators/canonical_validator_client.go
@@ -16,6 +16,7 @@ import (
 	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	"github.com/ava-labs/icm-services/config"
 	"github.com/ava-labs/icm-services/peers/utils"
+	sharedUtils "github.com/ava-labs/icm-services/utils"
 	"go.uber.org/zap"
 
 	pchainapi "github.com/ava-labs/avalanchego/vms/platformvm/api"
@@ -53,9 +54,9 @@ func (v *CanonicalValidatorClient) GetCurrentCanonicalValidatorSet(
 	ctx context.Context,
 	subnetID ids.ID,
 ) (avalancheWarp.CanonicalValidatorSet, error) {
-	// // Get the current canonical validator set of the source subnet.
-	// ctx, cancel := context.WithTimeout(context.Background(), sharedUtils.DefaultRPCTimeout)
-	// defer cancel()
+	// Get the current canonical validator set of the source subnet.
+	ctx, cancel := context.WithTimeout(ctx, sharedUtils.DefaultRPCTimeout)
+	defer cancel()
 	canonicalSubnetValidators, err := avalancheWarp.GetCanonicalValidatorSetFromSubnetID(
 		ctx,
 		v,

--- a/peers/validators/mocks/mock_canonical_validator_client.go
+++ b/peers/validators/mocks/mock_canonical_validator_client.go
@@ -44,18 +44,18 @@ func (m *MockCanonicalValidatorState) EXPECT() *MockCanonicalValidatorStateMockR
 }
 
 // GetCurrentCanonicalValidatorSet mocks base method.
-func (m *MockCanonicalValidatorState) GetCurrentCanonicalValidatorSet(subnetID ids.ID) (warp.CanonicalValidatorSet, error) {
+func (m *MockCanonicalValidatorState) GetCurrentCanonicalValidatorSet(ctx context.Context, subnetID ids.ID) (warp.CanonicalValidatorSet, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCurrentCanonicalValidatorSet", subnetID)
+	ret := m.ctrl.Call(m, "GetCurrentCanonicalValidatorSet", ctx, subnetID)
 	ret0, _ := ret[0].(warp.CanonicalValidatorSet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCurrentCanonicalValidatorSet indicates an expected call of GetCurrentCanonicalValidatorSet.
-func (mr *MockCanonicalValidatorStateMockRecorder) GetCurrentCanonicalValidatorSet(subnetID any) *gomock.Call {
+func (mr *MockCanonicalValidatorStateMockRecorder) GetCurrentCanonicalValidatorSet(ctx, subnetID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentCanonicalValidatorSet", reflect.TypeOf((*MockCanonicalValidatorState)(nil).GetCurrentCanonicalValidatorSet), subnetID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentCanonicalValidatorSet", reflect.TypeOf((*MockCanonicalValidatorState)(nil).GetCurrentCanonicalValidatorSet), ctx, subnetID)
 }
 
 // GetCurrentHeight mocks base method.

--- a/relayer/network_utils.go
+++ b/relayer/network_utils.go
@@ -86,7 +86,7 @@ func checkSufficientConnectedStake(
 	}
 
 	checkConns := func() error {
-		connectedValidators, err := network.GetConnectedCanonicalValidators(subnetID, false)
+		connectedValidators, err := network.GetConnectedCanonicalValidators(ctx, subnetID, false)
 		if err != nil {
 			logger.Error(
 				"Failed to retrieve currently connected validators",

--- a/signature-aggregator/aggregator/aggregator.go
+++ b/signature-aggregator/aggregator/aggregator.go
@@ -117,6 +117,7 @@ func (s *SignatureAggregator) Shutdown() {
 }
 
 func (s *SignatureAggregator) connectToQuorumValidators(
+	ctx context.Context,
 	log logging.Logger,
 	signingSubnet ids.ID,
 	quorumPercentage uint64,
@@ -127,7 +128,7 @@ func (s *SignatureAggregator) connectToQuorumValidators(
 	var connectedValidators *peers.ConnectedCanonicalValidators
 	var err error
 	connectOp := func() error {
-		connectedValidators, err = s.network.GetConnectedCanonicalValidators(signingSubnet, skipCache)
+		connectedValidators, err = s.network.GetConnectedCanonicalValidators(ctx, signingSubnet, skipCache)
 		if err != nil {
 			msg := "Failed to fetch connected canonical validators"
 			log.Error(
@@ -221,7 +222,7 @@ func (s *SignatureAggregator) CreateSignedMessage(
 		zap.Stringer("signingSubnet", signingSubnet),
 	)
 
-	connectedValidators, err := s.connectToQuorumValidators(log, signingSubnet, requiredQuorumPercentage, skipCache)
+	connectedValidators, err := s.connectToQuorumValidators(ctx, log, signingSubnet, requiredQuorumPercentage, skipCache)
 	if err != nil {
 		log.Error(
 			"Failed to fetch quorum of connected canonical validators",

--- a/signature-aggregator/aggregator/aggregator_test.go
+++ b/signature-aggregator/aggregator/aggregator_test.go
@@ -172,7 +172,7 @@ func TestCreateSignedMessageFailsWithNoValidators(t *testing.T) {
 	require.NoError(t, err)
 	mockNetwork.EXPECT().GetSubnetID(gomock.Any(), ids.Empty).Return(ids.Empty, nil)
 	mockNetwork.EXPECT().TrackSubnet(ids.Empty)
-	mockNetwork.EXPECT().GetConnectedCanonicalValidators(ids.Empty, false).Return(
+	mockNetwork.EXPECT().GetConnectedCanonicalValidators(gomock.Any(), ids.Empty, false).Return(
 		&peers.ConnectedCanonicalValidators{
 			ConnectedWeight: 0,
 			ValidatorSet: warp.CanonicalValidatorSet{
@@ -192,7 +192,7 @@ func TestCreateSignedMessageFailsWithoutSufficientConnectedStake(t *testing.T) {
 	require.NoError(t, err)
 	mockNetwork.EXPECT().GetSubnetID(gomock.Any(), ids.Empty).Return(ids.Empty, nil)
 	mockNetwork.EXPECT().TrackSubnet(ids.Empty)
-	mockNetwork.EXPECT().GetConnectedCanonicalValidators(ids.Empty, false).Return(
+	mockNetwork.EXPECT().GetConnectedCanonicalValidators(gomock.Any(), ids.Empty, false).Return(
 		&peers.ConnectedCanonicalValidators{
 			ConnectedWeight: 0,
 			ValidatorSet: warp.CanonicalValidatorSet{
@@ -254,7 +254,7 @@ func TestCreateSignedMessageRetriesAndFailsWithoutP2PResponses(t *testing.T) {
 	)
 
 	mockNetwork.EXPECT().TrackSubnet(subnetID)
-	mockNetwork.EXPECT().GetConnectedCanonicalValidators(subnetID, false).Return(
+	mockNetwork.EXPECT().GetConnectedCanonicalValidators(gomock.Any(), subnetID, false).Return(
 		connectedValidators,
 		nil,
 	)
@@ -345,7 +345,7 @@ func TestCreateSignedMessageSucceeds(t *testing.T) {
 			)
 
 			mockNetwork.EXPECT().TrackSubnet(subnetID)
-			mockNetwork.EXPECT().GetConnectedCanonicalValidators(subnetID, false).Return(
+			mockNetwork.EXPECT().GetConnectedCanonicalValidators(gomock.Any(), subnetID, false).Return(
 				connectedValidators,
 				nil,
 			)

--- a/signature-aggregator/api/api.go
+++ b/signature-aggregator/api/api.go
@@ -196,7 +196,7 @@ func signatureAggregationAPIHandler(
 			}
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultCreateSignedMessageTimeout)
+		ctx, cancel := context.WithTimeout(r.Context(), utils.DefaultCreateSignedMessageTimeout)
 		defer cancel()
 
 		signedMessage, err := aggregator.CreateSignedMessage(


### PR DESCRIPTION
## Why this should be merged
The application's handling of context in API calls demonstrates an oversight in the propagation of timeouts and cancellations. This mismanagement significantly impacts the application's ability to respond promptly to upstream cancellations and timeouts, potentially leading to unnecessary resource utilization and degraded performance.

In the `canonical_validator_client.go` file, the [GetCurrentCanonicalValidatorSet](https://github.com/ava-labs/icm-services/blob/11c6cafa6d5a8572a2f48364e850491db5c86b80/peers/validators/canonical_validator_client.go#L53) method is tasked with retrieving the validator set for a given subnet from the P-Chain. Unlike other methods within the same file that correctly accept a `context.Context` from their callers, `GetCurrentCanonicalValidatorSet` independently instantiates a new context using `context.Background()` and applies a hardcoded timeout. This approach effectively isolates the method's execution context from any parent context, thereby obstructing the flow of cancellation signals from higher-level operations.

Similarly, the [signatureAggregationAPIHandler](https://github.com/ava-labs/icm-services/blob/11c6cafa6d5a8572a2f48364e850491db5c86b80/signature-aggregator/api/api.go#L199) function within the signature-aggregator `api.go` file exhibits a parallel issue. It creates a new context for processing message signing operations based on `context.Background()`, disregarding the context associated with the incoming HTTP request, `r.Context()`.

Consider modifying the `GetCurrentCanonicalValidatorSet` method to accept a `context.Context` parameter from its caller. In addition, consider making an adjustment to the context creation strategy of the `signatureAggregationAPIHandler `function to use the extended context. Implementing these recommendations will improve the application's ability to manage resources effectively and respond to operational dynamics in a timely manner, thereby enhancing its reliability and performance.

## How this works

## How this was tested

## How is this documented