### PR TITLE
N-01 Unbuffered Error Channel Leads to Potential Goroutine Leaks

### DIFF
--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -300,6 +300,7 @@ func main() {
 				relayerHealth[sourceBlockchain.GetBlockchainID()],
 				minHeights[sourceBlockchain.GetBlockchainID()],
 				messageCoordinator,
+				cfg.MaxConcurrentMessages,
 			)
 		})
 	}


### PR DESCRIPTION
## Why this should be merged
In the [processLogs](https://github.com/ava-labs/icm-services/blob/11c6cafa6d5a8572a2f48364e850491db5c86b80/relayer/listener.go#L161) function, downstream errors from [block processing](https://github.com/ava-labs/icm-services/blob/11c6cafa6d5a8572a2f48364e850491db5c86b80/relayer/application_relayer.go#L184) are sent to an unbuffered channel, errChan. This channel is consumed by the main select loop, which processes one event at a time. While this works for sequential errors, it creates a race condition in scenarios with concurrent failures.

If multiple `ProcessBlock` goroutines encounter an error at the same time, they will all attempt to send over the unbuffered channel. While the first one will succeed, the others will block indefinitely, waiting for a receiver. This is particularly problematic because the `processLogs` loop can terminate for reasons unrelated to the errChan, such as a
WebSocket subscription error or context cancellation. If the loop exits while other goroutines are still blocked waiting to send their errors, those goroutines will be orphaned and leak forever. Although, in the current state of the application, the program would exit after the first error in the listener.

Consider replacing the unbuffered channel with a buffered channel to report multiple errors without blocking. This will allow the system to accommodate the reporting of multiple errors concurrently. Making the code more future-proof, even during a cascade of failures or an abrupt shutdown of the listener loop.

## How this works

## How this was tested

## How is this documented