### PR TITLE
L-05 Lack of Graceful Shutdown for OS Signals

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -38,6 +38,7 @@ func (k DataKey) String() string {
 type RelayerDatabase interface {
 	Get(relayerID common.Hash, key DataKey) ([]byte, error)
 	Put(relayerID common.Hash, key DataKey, value []byte) error
+	Close() error
 }
 
 func NewDatabase(logger logging.Logger, cfg *config.Config) (RelayerDatabase, error) {

--- a/database/json_file_storage.go
+++ b/database/json_file_storage.go
@@ -208,3 +208,7 @@ func (s *JSONFileStorage) read(relayerID common.Hash, v interface{}) (bool, erro
 	// Return true to indicate that the file exists and we read from it successfully
 	return true, nil
 }
+
+func (s *JSONFileStorage) Close() error {
+	return nil
+}

--- a/database/mocks/mock_database.go
+++ b/database/mocks/mock_database.go
@@ -41,6 +41,20 @@ func (m *MockRelayerDatabase) EXPECT() *MockRelayerDatabaseMockRecorder {
 	return m.recorder
 }
 
+// Close mocks base method.
+func (m *MockRelayerDatabase) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockRelayerDatabaseMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockRelayerDatabase)(nil).Close))
+}
+
 // Get mocks base method.
 func (m *MockRelayerDatabase) Get(relayerID common.Hash, key database.DataKey) ([]byte, error) {
 	m.ctrl.T.Helper()

--- a/database/redis.go
+++ b/database/redis.go
@@ -72,6 +72,10 @@ func (r *RedisDatabase) Put(relayerID common.Hash, key DataKey, value []byte) er
 	return nil
 }
 
+func (r *RedisDatabase) Close() error {
+	return r.client.Close()
+}
+
 func constructCompositeKey(relayerID common.Hash, key DataKey) string {
 	const keyDelimiter = "-"
 	return strings.Join([]string{relayerID.Hex(), key.String()}, keyDelimiter)

--- a/database/utils_test.go
+++ b/database/utils_test.go
@@ -95,3 +95,7 @@ func (m *mockDB) Get(relayerID common.Hash, key DataKey) ([]byte, error) {
 func (m *mockDB) Put(relayerID common.Hash, key DataKey, value []byte) error {
 	return nil
 }
+
+func (m *mockDB) Close() error {
+	return nil
+}

--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"runtime"
 	"syscall"
 	"time"
 

--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -197,6 +197,7 @@ func main() {
 		logger.Fatal("Failed to create database", zap.Error(err))
 		os.Exit(1)
 	}
+	defer db.Close()
 
 	// Initialize the global write ticker
 	ticker := utils.NewTicker(cfg.DBWriteIntervalSeconds)


### PR DESCRIPTION
## Why this should be merged
Both `main.go` [[1](https://github.com/ava-labs/icm-services/blob/11c6cafa6d5a8572a2f48364e850491db5c86b80/relayer/main/main.go), [2](https://github.com/ava-labs/icm-services/blob/11c6cafa6d5a8572a2f48364e850491db5c86b80/signature-aggregator/main/main.go)] applications follow a similar initialization pattern. They set up all required resources, such as the P2P network, database connections, and HTTP servers, and then conclude with a blocking call ( `errgroup.Wait()` for the relayer, `http.ListenAndServe` for the aggregator) that keeps the process alive. Cleanup functions, like network.Shutdown(), are scheduled using defer.

This application structure does not handle OS signals like `SIGINT` or `SIGTERM`. When the process receives one of these signals, it terminates immediately and ungracefully. The blocking call at the end of main is interrupted, and the process exits before the deferred cleanup functions have a chance to run. The Redis database connection is not explicitly closed either. Furthermore, any in-flight HTTP requests are cut off. Lastly, the latest processed block height from the `CheckpointManager` may not be written to the database, causing the relayer to re-process blocks on restart.

Consider implementing a standard graceful shutdown mechanism in both `main` functions. This involves listening for OS signals on a channel and coordinating a clean, ordered shutdown of all components.

## How this works

## How this was tested

## How is this documented