### PR TITLE
L-04 Race Condition in Signature Cache Leads to Lost Signatures

### DIFF
--- a/signature-aggregator/aggregator/cache.go
+++ b/signature-aggregator/aggregator/cache.go
@@ -16,7 +16,9 @@ import (
 type SignatureCache struct {
 	// map of warp message ID to a map of public keys to signatures
 	signatures *lru.Cache[ids.ID, map[PublicKeyBytes]SignatureBytes]
-	mu         sync.RWMutex
+	// protects against the race condition where multiple goroutines are trying to
+	// enter a signature for a message ID that is not currently in the cache.
+	mu sync.Mutex
 }
 
 type PublicKeyBytes [bls.PublicKeyLen]byte


### PR DESCRIPTION
## Why this should be merged
The `cache.go` file implements a `SignatureCache` using a thread-safe LRU cache to store
BLS signatures for different messages. The SignatureAggregator uses this cache to
collect signatures from multiple validators before aggregating them.
The `Add` method is intended to add a new signature for a given `message ID` ( `msgID`). It first
checks if an entry for the `msgID` already exists. If not, it creates a new map, adds the
signature to it, and then stores the map in the cache. If an entry does exist, it retrieves the
existing map of signatures, adds the new signature to it, and writes the updated map back to
the cache. This `Add` method is called concurrently from the `handleResponse` function in
`aggregator.go`, as the aggregator processes signature responses from multiple peers in
parallel goroutines.
However, the `Add` method in `SignatureCache` contains a race condition. The read
( `c.Get`), modify ( `sigs[pubKey] = signature`), and write ( `c.signatures.Add`)
sequence is not atomic. While the underlying `lru.Cache` is thread-safe for its own
operations, the value it stores (the `map[PublicKeyBytes]SignatureBytes`) is not
protected during this multi-step update process.
If two goroutines attempt to call `Add` for the same `msgID` that is not yet in the cache, the
following can occur:
1. Both goroutines will execute `c.Get(msgID)` and find no existing entry.
2. Each goroutine will then create its own, separate new map for the signatures.
3. Each goroutine will add its respective signature to its local map.
4. Both will then call `c.signatures.Add` with their local map. The second call will
overwrite the value set by the first.

As a result, the first signature to be "added" is lost, and the final map in the cache will only
contain the signature from the last goroutine to write to it.

Consider introducing a mutex to ensure that the read-modify-write operation in the `Add`
method is performed atomically. The cache should be locked for the duration of the operation
so that interference between multiple goroutines is prevented and correct addition of all
signatures to the map is ensured.

## How this works
Adds a lock that is held during the `Add` operation
## How this was tested
CI
## How is this documented