### PR TITLE
N-06 Unused Code

### DIFF
--- a/signature-aggregator/aggregator/aggregator.go
+++ b/signature-aggregator/aggregator/aggregator.go
@@ -112,10 +112,6 @@ func NewSignatureAggregator(
 	return &sa, nil
 }
 
-func (s *SignatureAggregator) Shutdown() {
-	s.network.Shutdown()
-}
-
 func (s *SignatureAggregator) connectToQuorumValidators(
 	ctx context.Context,
 	log logging.Logger,

--- a/signature-aggregator/config/config.go
+++ b/signature-aggregator/config/config.go
@@ -45,7 +45,6 @@ type Config struct {
 
 	// convenience fields
 	trackedSubnets set.Set[ids.ID]
-	myNodeID       ids.NodeID
 	tlsCert        *tls.Certificate
 }
 

--- a/signature-aggregator/config/config.go
+++ b/signature-aggregator/config/config.go
@@ -98,10 +98,6 @@ func (c *Config) GetTrackedSubnets() set.Set[ids.ID] {
 	return c.trackedSubnets
 }
 
-func (c *Config) GetNodeID() ids.NodeID {
-	return c.myNodeID
-}
-
 func (c *Config) GetTLSCert() *tls.Certificate {
 	return c.tlsCert
 }


### PR DESCRIPTION
## Why this should be merged
Throughout the codebase, multiple instances of unused code were identified that, if removed, could streamline the project and enhance its maintainability. Addressing these instances not only reduces the codebase's complexity but also minimizes potential confusion for developers navigating the project. Below are the specific recommendations for removal:
  - The `GetNodeID` function and, therefore, the myNodeID field are unused. Consider removing the function and field.
  - The `GetMinimumHeight` and `GetCurrentHeight` functions are unused, while the GetCurrentValidatorSet function is not needed. Consider removing these functions and adding the GetSubnetID function to the CanonicalValidatorState interface instead of validators.State. (Won't fix changing of the interfaces since we don't control validators.State)
  - The `Shutdown` function of the `SignatureAggregator` is not used and could be removed.

Consider applying the above-listed code suggestions to reduce the code footprint and make the codebase more readable.

## How this works

## How this was tested

## How is this documented