### PR TITLE
explicitly add subnet ID to tracked Subnets to fix E2E flakiness

### DIFF
--- a/tests/validators_only_network.go
+++ b/tests/validators_only_network.go
@@ -65,6 +65,7 @@ func ValidatorsOnlyNetwork(network *network.LocalNetwork, teleporter utils.Telep
 	certPath := dir + "/cert.pem"
 
 	signatureAggregatorConfig := baseConfig
+	signatureAggregatorConfig.TrackedSubnetIDs = []string{l1BInfo.SubnetID.String()}
 	signatureAggregatorConfig.TLSCertPath = certPath
 	signatureAggregatorConfig.TLSKeyPath = keyPath
 


### PR DESCRIPTION
## Why this should be merged

This should hopefully fix the recent flakiness of this test. It looks like there is a recent regression in the time to dynamic discovery of new subnetID IPs making this test flaky. This should be an okay path since we will be changing the way that peers are discovered soon. 

## How this works

## How this was tested

## How is this documented