### PR TITLE
Fix panic on shutdown

### DIFF
--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -221,7 +221,9 @@ func main() {
 		)
 		os.Exit(1)
 	}
-	defer deciderConnection.Close()
+	if deciderConnection != nil {
+		defer deciderConnection.Close()
+	}
 
 	messageHandlerFactories, err := createMessageHandlerFactories(
 		logger,


### PR DESCRIPTION
## Why this should be merged
Closes https://github.com/ava-labs/icm-services/issues/871

If we provide an empty decider url, `createDeciderConnection()` validly returns `nil`. This then gets used to make an `emptyDeciderClient` in `NewMessageHandlerFactory`. When the defer is run on the the `nil`, it panics.

We could probably return some sort of empty decider connection object instead, but this is a quick and easy fix.

## How this works

## How this was tested

## How is this documented