### PR TITLE
Fetch network upgrade info at relayer config initialize time

### DIFF
--- a/relayer/config/config.go
+++ b/relayer/config/config.go
@@ -11,12 +11,15 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
+	"time"
 
 	basecfg "github.com/ava-labs/icm-services/config"
 	"github.com/ava-labs/icm-services/peers"
 	"go.uber.org/zap"
 
+	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
 
@@ -88,6 +91,8 @@ type Config struct {
 	tlsCert                *tls.Certificate
 	blockchainIDToSubnetID map[ids.ID]ids.ID
 	trackedSubnets         set.Set[ids.ID]
+
+	networkUpgradeConfig *upgrade.Config
 }
 
 func DisplayUsageText() {
@@ -246,10 +251,10 @@ func getWarpConfig(client ethclient.Client) (*warp.Config, error) {
 }
 
 // Initializes Warp configurations (quorum and self-signing settings) for each destination subnet
-func (c *Config) initializeWarpConfigs() error {
+func (c *Config) initializeWarpConfigs(ctx context.Context) error {
 	// Fetch the Warp config values for each destination subnet.
 	for _, destinationSubnet := range c.DestinationBlockchains {
-		err := destinationSubnet.initializeWarpConfigs()
+		err := destinationSubnet.initializeWarpConfigs(context.Background())
 		if err != nil {
 			return fmt.Errorf(
 				"failed to initialize Warp config for destination subnet %s: %w",
@@ -276,8 +281,21 @@ func (c *Config) initializeTrackedSubnets() error {
 	return nil
 }
 
-func (c *Config) Initialize() error {
-	if err := c.initializeWarpConfigs(); err != nil {
+func (c *Config) initializeNetworkUpgradeConfig(ctx context.Context) error {
+	infoClient := info.NewClient(c.InfoAPI.BaseURL)
+	upgradeConfig, err := infoClient.Upgrades(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get network upgrade config: %w", err)
+	}
+	c.networkUpgradeConfig = upgradeConfig
+	return nil
+}
+
+func (c *Config) Initialize(ctx context.Context) error {
+	if err := c.initializeNetworkUpgradeConfig(ctx); err != nil {
+		return err
+	}
+	if err := c.initializeWarpConfigs(ctx); err != nil {
 		return err
 	}
 	return c.initializeTrackedSubnets()
@@ -320,6 +338,10 @@ func (c *Config) GetTLSCert() *tls.Certificate {
 
 func (c *Config) LogSafeField() zap.Field {
 	return zap.Any("config", c.sanitizeForLogging())
+}
+
+func (c *Config) IsGraniteActivated() bool {
+	return c.networkUpgradeConfig.IsGraniteActivated(time.Now())
 }
 
 func (c *Config) sanitizeForLogging() map[string]any {

--- a/relayer/config/destination_blockchain.go
+++ b/relayer/config/destination_blockchain.go
@@ -152,7 +152,7 @@ func (s *DestinationBlockchain) GetBlockchainID() ids.ID {
 	return s.blockchainID
 }
 
-func (s *DestinationBlockchain) initializeWarpConfigs() error {
+func (s *DestinationBlockchain) initializeWarpConfigs(ctx context.Context) error {
 	blockchainID, err := ids.FromString(s.BlockchainID)
 	if err != nil {
 		return fmt.Errorf("invalid blockchainID in configuration. error: %w", err)
@@ -171,7 +171,7 @@ func (s *DestinationBlockchain) initializeWarpConfigs() error {
 	}
 
 	client, err := utils.NewEthClientWithConfig(
-		context.Background(),
+		ctx,
 		s.RPCEndpoint.BaseURL,
 		s.RPCEndpoint.HTTPHeaders,
 		s.RPCEndpoint.QueryParams,

--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -96,7 +96,7 @@ func main() {
 
 	// Initialize the Warp Config values and trackedSubnets by fetching via RPC
 	// We do this here so that BuildConfig doesn't need to make RPC calls
-	if err = cfg.Initialize(); err != nil {
+	if err = cfg.Initialize(parentCtx); err != nil {
 		logger.Fatal("couldn't initialize config", zap.Error(err))
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Why this should be merged

Fetches network upgrade information at config building time that allows for switching behavior based on network upgrade information without hardcoding of upgrade times like was done previously. 

## How this works

## How this was tested

## How is this documented