### PR TITLE
Fix relayer semaphore logic

### DIFF
--- a/relayer/application_relayer.go
+++ b/relayer/application_relayer.go
@@ -200,10 +200,11 @@ func (r *ApplicationRelayer) ProcessHeight(
 	)
 	var eg errgroup.Group
 	for _, handler := range handlers {
-		// Acquire the semaphore to limit the number of messages being processed concurrently globally.
-		r.processMessageSemaphore <- struct{}{}
-
+		handler := handler // capture the handler to ensure goroutines use the correct value
 		eg.Go(func() error {
+			// Acquire the semaphore to limit the number of messages being processed concurrently globally.
+			// This needs to be done in the same goroutine as the message processing to avoid deadlocks.
+			r.processMessageSemaphore <- struct{}{}
 			defer func() {
 				<-r.processMessageSemaphore
 			}()


### PR DESCRIPTION
## Why this should be merged

This fixes two issues: 

1.  handler wasn't captured and the loop variable was being passed to the goroutine which means that at higher loads it was possible to drop a message and try sending a later message twice.
2. Semaphore was acquired outside of the goroutine that had a deferred release which could cause a deadlock if all semaphores were acquired prior to goroutines doing the processing getting scheduled .

## How this works

## How this was tested

## How is this documented