### PR TITLE
refactor: use maps.Copy to simplify the code

### DIFF
--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 	"net/http"
 	"os"
 	"os/signal"
@@ -517,9 +518,7 @@ func createApplicationRelayers(
 			return nil, nil, err
 		}
 
-		for relayerID, applicationRelayer := range applicationRelayersForSource {
-			applicationRelayers[relayerID] = applicationRelayer
-		}
+		maps.Copy(applicationRelayers, applicationRelayersForSource)
 		minHeights[sourceBlockchain.GetBlockchainID()] = minHeight
 
 		logger.Info(


### PR DESCRIPTION
## Why this should be merged

There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.

## How this works

## How this was tested

## How is this documented