### PR TITLE
Fix e2e CI job for pushes to main

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,41 +19,43 @@ jobs:
   # JOB to run change detection
   changes:
     runs-on: ubuntu-22.04
-    # Required permissions
-    permissions:
-      pull-requests: read
     # Set job outputs to values from filter step
     outputs:
       contracts: ${{ steps.filter.outputs.contracts }}
       services: ${{ steps.filter.outputs.services }}
     steps:
-    # For pull requests it's not necessary to checkout the code
-    - uses: dorny/paths-filter@v3
-      id: filter
-      with:
-        filters: |
-          contracts:
-            - '.github/workflows/e2e.yml'
-            - 'go.mod'
-            - 'icm-contracts/contracts/**'
-            - 'icm-contracts/tests/**'
-            - 'icm-contracts/utils/**'
-            - 'scripts/**'
-          services:
-            - '.github/workflows/e2e.yml'
-            - 'go.mod'
-            - 'icm-contracts/utils/**'
-            - 'config/**'
-            - 'database/**'
-            - 'messages/**'
-            - 'peers/**'
-            - 'relayer/**'
-            - 'signature-aggregator/**'
-            - 'tests/**'
-            - 'scripts/**'
-            - 'types/**'
-            - 'utils/**'
-            - 'vms/**'
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Detect changed components
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            contracts:
+              - '.github/workflows/e2e.yml'
+              - 'go.mod'
+              - 'icm-contracts/contracts/**'
+              - 'icm-contracts/tests/**'
+              - 'icm-contracts/utils/**'
+              - 'scripts/**'
+            services:
+              - '.github/workflows/e2e.yml'
+              - 'go.mod'
+              - 'icm-contracts/utils/**'
+              - 'config/**'
+              - 'database/**'
+              - 'messages/**'
+              - 'peers/**'
+              - 'relayer/**'
+              - 'signature-aggregator/**'
+              - 'tests/**'
+              - 'scripts/**'
+              - 'types/**'
+              - 'utils/**'
+              - 'vms/**'
 
   teleporter_e2e:
     name: teleporter-e2e-tests


### PR DESCRIPTION
## Why this should be merged
The new e2e test job failed on a push to main because while PRs will check out the repo automatically, pushes do not, so this just always checks out the code anyway. [CI failure here](https://github.com/ava-labs/icm-services/actions/runs/19866736085/job/56931617513)

## How this works

## How this was tested

## How is this documented