### PR TITLE
Remove Redundant import

### DIFF
--- a/icm-contracts/tests/flows/services/allowed_addresses.go
+++ b/icm-contracts/tests/flows/services/allowed_addresses.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ava-labs/icm-services/icm-contracts/tests/interfaces"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/network"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/utils"
-	testUtils "github.com/ava-labs/icm-services/icm-contracts/tests/utils"
 	"github.com/ava-labs/icm-services/relayer/config"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/crypto"
@@ -46,7 +45,7 @@ func AllowedAddresses(
 	l1AInfo := network.GetPrimaryNetworkInfo()
 	l1BInfo, _ := network.GetTwoL1s()
 	fundedAddress, fundedKey := network.GetFundedAccountInfo()
-	err := testUtils.ClearRelayerStorage()
+	err := utils.ClearRelayerStorage()
 	Expect(err).Should(BeNil())
 
 	//
@@ -56,7 +55,7 @@ func AllowedAddresses(
 	log.Info("Funding relayer address on all subnets")
 	relayerKey, err := crypto.GenerateKey()
 	Expect(err).Should(BeNil())
-	testUtils.FundRelayers(ctx, []interfaces.L1TestInfo{l1AInfo, l1BInfo}, fundedKey, relayerKey)
+	utils.FundRelayers(ctx, []interfaces.L1TestInfo{l1AInfo, l1BInfo}, fundedKey, relayerKey)
 
 	// Create distinct key/address pairs to be used in the configuration, and fund them
 	var allowedKeys []*ecdsa.PrivateKey
@@ -67,7 +66,7 @@ func AllowedAddresses(
 		allowedKey, err := crypto.GenerateKey()
 		Expect(err).Should(BeNil())
 		allowedAddress := crypto.PubkeyToAddress(allowedKey.PublicKey)
-		testUtils.FundRelayers(ctx, []interfaces.L1TestInfo{l1AInfo, l1BInfo}, fundedKey, allowedKey)
+		utils.FundRelayers(ctx, []interfaces.L1TestInfo{l1AInfo, l1BInfo}, fundedKey, allowedKey)
 		allowedKeys = append(allowedKeys, allowedKey)
 		allowedAddresses = append(allowedAddresses, allowedAddress)
 		allowedAddressesStr = append(allowedAddressesStr, allowedAddress.String())
@@ -87,7 +86,7 @@ func AllowedAddresses(
 
 	// All sources -> All destinations
 	// Will send from allowed Address 0 -> 0
-	relayerConfig1 := testUtils.CreateDefaultRelayerConfig(
+	relayerConfig1 := utils.CreateDefaultRelayerConfig(
 		log,
 		teleporter,
 		[]interfaces.L1TestInfo{l1AInfo, l1BInfo},
@@ -98,7 +97,7 @@ func AllowedAddresses(
 
 	// Specific source -> All destinations
 	// Will send from allowed Address 1 -> 0
-	relayerConfig2 := testUtils.CreateDefaultRelayerConfig(
+	relayerConfig2 := utils.CreateDefaultRelayerConfig(
 		log,
 		teleporter,
 		[]interfaces.L1TestInfo{l1AInfo, l1BInfo},
@@ -114,7 +113,7 @@ func AllowedAddresses(
 
 	// All sources -> Specific destination
 	// Will send from allowed Address 2 -> 0
-	relayerConfig3 := testUtils.CreateDefaultRelayerConfig(
+	relayerConfig3 := utils.CreateDefaultRelayerConfig(
 		log,
 		teleporter,
 		[]interfaces.L1TestInfo{l1AInfo, l1BInfo},
@@ -141,7 +140,7 @@ func AllowedAddresses(
 
 	// Specific source -> Specific destination
 	// Will send from allowed Address 3 -> 0
-	relayerConfig4 := testUtils.CreateDefaultRelayerConfig(
+	relayerConfig4 := utils.CreateDefaultRelayerConfig(
 		log,
 		teleporter,
 		[]interfaces.L1TestInfo{l1AInfo, l1BInfo},
@@ -168,10 +167,10 @@ func AllowedAddresses(
 	relayerConfig4.APIPort = 8083
 	relayerConfig4.MetricsPort = 9093
 
-	relayerConfigPath1 := testUtils.WriteRelayerConfig(log, relayerConfig1, relayerCfgFname1)
-	relayerConfigPath2 := testUtils.WriteRelayerConfig(log, relayerConfig2, relayerCfgFname2)
-	relayerConfigPath3 := testUtils.WriteRelayerConfig(log, relayerConfig3, relayerCfgFname3)
-	relayerConfigPath4 := testUtils.WriteRelayerConfig(log, relayerConfig4, relayerCfgFname4)
+	relayerConfigPath1 := utils.WriteRelayerConfig(log, relayerConfig1, relayerCfgFname1)
+	relayerConfigPath2 := utils.WriteRelayerConfig(log, relayerConfig2, relayerCfgFname2)
+	relayerConfigPath3 := utils.WriteRelayerConfig(log, relayerConfig3, relayerCfgFname3)
+	relayerConfigPath4 := utils.WriteRelayerConfig(log, relayerConfig4, relayerCfgFname4)
 
 	//
 	// Test Relaying from Subnet A to Subnet B
@@ -180,7 +179,7 @@ func AllowedAddresses(
 
 	// Test Relayer 1
 	log.Info("Testing Relayer 1: All sources -> All destinations")
-	relayerCleanup, readyChan := testUtils.RunRelayerExecutable(
+	relayerCleanup, readyChan := utils.RunRelayerExecutable(
 		ctx,
 		log,
 		relayerConfigPath1,
@@ -192,10 +191,10 @@ func AllowedAddresses(
 	log.Info("Waiting for the relayer to start up")
 	startupCtx, startupCancel := context.WithTimeout(ctx, 15*time.Second)
 	defer startupCancel()
-	testUtils.WaitForChannelClose(startupCtx, readyChan)
+	utils.WaitForChannelClose(startupCtx, readyChan)
 
 	// Allowed by Relayer 1
-	testUtils.RelayBasicMessage(
+	utils.RelayBasicMessage(
 		ctx,
 		log,
 		teleporter,
@@ -212,7 +211,7 @@ func AllowedAddresses(
 
 	// Test Relayer 2
 	log.Info("Testing Relayer 2: Specific source -> All destinations")
-	relayerCleanup, readyChan = testUtils.RunRelayerExecutable(
+	relayerCleanup, readyChan = utils.RunRelayerExecutable(
 		ctx,
 		log,
 		relayerConfigPath2,
@@ -224,10 +223,10 @@ func AllowedAddresses(
 	log.Info("Waiting for the relayer to start up")
 	startupCtx, startupCancel = context.WithTimeout(ctx, 15*time.Second)
 	defer startupCancel()
-	testUtils.WaitForChannelClose(startupCtx, readyChan)
+	utils.WaitForChannelClose(startupCtx, readyChan)
 
 	// Disallowed by Relayer 2
-	_, _, id := testUtils.SendBasicTeleporterMessage(
+	_, _, id := utils.SendBasicTeleporterMessage(
 		ctx,
 		log,
 		teleporter,
@@ -245,7 +244,7 @@ func AllowedAddresses(
 	}, 10*time.Second, 500*time.Millisecond).Should(BeFalse())
 
 	// Allowed by Relayer 2
-	testUtils.RelayBasicMessage(
+	utils.RelayBasicMessage(
 		ctx,
 		log,
 		teleporter,
@@ -262,7 +261,7 @@ func AllowedAddresses(
 
 	// Test Relayer 3
 	log.Info("Testing Relayer 3: All sources -> Specific destination")
-	relayerCleanup, readyChan = testUtils.RunRelayerExecutable(
+	relayerCleanup, readyChan = utils.RunRelayerExecutable(
 		ctx,
 		log,
 		relayerConfigPath3,
@@ -274,10 +273,10 @@ func AllowedAddresses(
 	log.Info("Waiting for the relayer to start up")
 	startupCtx, startupCancel = context.WithTimeout(ctx, 15*time.Second)
 	defer startupCancel()
-	testUtils.WaitForChannelClose(startupCtx, readyChan)
+	utils.WaitForChannelClose(startupCtx, readyChan)
 
 	// Disallowed by Relayer 3
-	_, _, id = testUtils.SendBasicTeleporterMessage(
+	_, _, id = utils.SendBasicTeleporterMessage(
 		ctx,
 		log,
 		teleporter,
@@ -295,7 +294,7 @@ func AllowedAddresses(
 	}, 10*time.Second, 500*time.Millisecond).Should(BeFalse())
 
 	// Allowed by Relayer 3
-	testUtils.RelayBasicMessage(
+	utils.RelayBasicMessage(
 		ctx,
 		log,
 		teleporter,
@@ -312,7 +311,7 @@ func AllowedAddresses(
 
 	// Test Relayer 4
 	log.Info("Testing Relayer 4: Specific source -> Specific destination")
-	relayerCleanup, readyChan = testUtils.RunRelayerExecutable(
+	relayerCleanup, readyChan = utils.RunRelayerExecutable(
 		ctx,
 		log,
 		relayerConfigPath4,
@@ -323,10 +322,10 @@ func AllowedAddresses(
 	// Wait for relayer to start up
 	startupCtx, startupCancel = context.WithTimeout(ctx, 15*time.Second)
 	defer startupCancel()
-	testUtils.WaitForChannelClose(startupCtx, readyChan)
+	utils.WaitForChannelClose(startupCtx, readyChan)
 
 	// Disallowed by Relayer 4
-	_, _, id = testUtils.SendBasicTeleporterMessage(
+	_, _, id = utils.SendBasicTeleporterMessage(
 		ctx,
 		log,
 		teleporter,
@@ -344,7 +343,7 @@ func AllowedAddresses(
 	}, 10*time.Second, 500*time.Millisecond).Should(BeFalse())
 
 	// Allowed by Relayer 4
-	testUtils.RelayBasicMessage(
+	utils.RelayBasicMessage(
 		ctx,
 		log,
 		teleporter,
@@ -398,7 +397,7 @@ func AllowedAddresses(
 		),
 	)
 	relayerKeys := []database.RelayerID{relayerID1, relayerID2, relayerID3, relayerID4}
-	jsonDB, err := database.NewJSONFileStorage(logging.NoLog{}, testUtils.StorageLocation, relayerKeys)
+	jsonDB, err := database.NewJSONFileStorage(logging.NoLog{}, utils.StorageLocation, relayerKeys)
 	Expect(err).Should(BeNil())
 
 	// Fetch the checkpointed heights from the shared database

--- a/icm-contracts/tests/flows/services/batch_relay.go
+++ b/icm-contracts/tests/flows/services/batch_relay.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ava-labs/icm-services/icm-contracts/tests/interfaces"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/network"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/utils"
-	testUtils "github.com/ava-labs/icm-services/icm-contracts/tests/utils"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/crypto"
@@ -29,20 +28,20 @@ func BatchRelay(
 ) {
 	l1AInfo, l1BInfo := network.GetTwoL1s()
 	fundedAddress, fundedKey := network.GetFundedAccountInfo()
-	err := testUtils.ClearRelayerStorage()
+	err := utils.ClearRelayerStorage()
 	Expect(err).Should(BeNil())
 
 	//
 	// Deploy the batch messenger contracts
 	//
-	_, batchMessengerA := testUtils.DeployBatchCrossChainMessenger(
+	_, batchMessengerA := utils.DeployBatchCrossChainMessenger(
 		ctx,
 		fundedKey,
 		teleporter,
 		fundedAddress,
 		l1AInfo,
 	)
-	batchMessengerAddressB, batchMessengerB := testUtils.DeployBatchCrossChainMessenger(
+	batchMessengerAddressB, batchMessengerB := utils.DeployBatchCrossChainMessenger(
 		ctx,
 		fundedKey,
 		teleporter,
@@ -57,12 +56,12 @@ func BatchRelay(
 	log.Info("Funding relayer address on all subnets")
 	relayerKey, err := crypto.GenerateKey()
 	Expect(err).Should(BeNil())
-	testUtils.FundRelayers(ctx, []interfaces.L1TestInfo{l1AInfo, l1BInfo}, fundedKey, relayerKey)
+	utils.FundRelayers(ctx, []interfaces.L1TestInfo{l1AInfo, l1BInfo}, fundedKey, relayerKey)
 
 	//
 	// Set up relayer config
 	//
-	relayerConfig := testUtils.CreateDefaultRelayerConfig(
+	relayerConfig := utils.CreateDefaultRelayerConfig(
 		log,
 		teleporter,
 		[]interfaces.L1TestInfo{l1AInfo, l1BInfo},
@@ -71,10 +70,10 @@ func BatchRelay(
 		relayerKey,
 	)
 
-	relayerConfigPath := testUtils.WriteRelayerConfig(log, relayerConfig, testUtils.DefaultRelayerCfgFname)
+	relayerConfigPath := utils.WriteRelayerConfig(log, relayerConfig, utils.DefaultRelayerCfgFname)
 
 	log.Info("Starting the relayer")
-	relayerCleanup, readyChan := testUtils.RunRelayerExecutable(
+	relayerCleanup, readyChan := utils.RunRelayerExecutable(
 		ctx,
 		log,
 		relayerConfigPath,
@@ -86,7 +85,7 @@ func BatchRelay(
 	log.Info("Waiting for the relayer to start up")
 	startupCtx, startupCancel := context.WithTimeout(ctx, 15*time.Second)
 	defer startupCancel()
-	testUtils.WaitForChannelClose(startupCtx, readyChan)
+	utils.WaitForChannelClose(startupCtx, readyChan)
 
 	//
 	// Send a batch message from subnet A -> B

--- a/icm-contracts/tests/flows/services/manual_message.go
+++ b/icm-contracts/tests/flows/services/manual_message.go
@@ -16,8 +16,6 @@ import (
 	"github.com/ava-labs/icm-services/icm-contracts/tests/interfaces"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/network"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/utils"
-	teleporterTestUtils "github.com/ava-labs/icm-services/icm-contracts/tests/utils"
-	testUtils "github.com/ava-labs/icm-services/icm-contracts/tests/utils"
 	offchainregistry "github.com/ava-labs/icm-services/messages/off-chain-registry"
 	"github.com/ava-labs/icm-services/relayer/api"
 	"github.com/ava-labs/libevm/common"
@@ -38,7 +36,7 @@ func ManualMessage(
 	cChainInfo := network.GetPrimaryNetworkInfo()
 	l1AInfo, l1BInfo := network.GetTwoL1s()
 	fundedAddress, fundedKey := network.GetFundedAccountInfo()
-	err := testUtils.ClearRelayerStorage()
+	err := utils.ClearRelayerStorage()
 	Expect(err).Should(BeNil())
 
 	//
@@ -55,7 +53,7 @@ func ManualMessage(
 	log.Info("Funding relayer address on all subnets")
 	relayerKey, err := crypto.GenerateKey()
 	Expect(err).Should(BeNil())
-	testUtils.FundRelayers(ctx, []interfaces.L1TestInfo{cChainInfo}, fundedKey, relayerKey)
+	utils.FundRelayers(ctx, []interfaces.L1TestInfo{cChainInfo}, fundedKey, relayerKey)
 
 	//
 	// Define the off-chain Warp message
@@ -68,21 +66,21 @@ func ManualMessage(
 	// Set up the nodes to accept the off-chain message
 	//
 	// Create chain config file with off chain message for each chain
-	unsignedMessage, warpEnabledChainConfigC := teleporterTestUtils.InitOffChainMessageChainConfig(
+	unsignedMessage, warpEnabledChainConfigC := utils.InitOffChainMessageChainConfig(
 		networkID,
 		cChainInfo,
 		teleporter.TeleporterRegistryAddress(cChainInfo),
 		newProtocolAddress,
 		2,
 	)
-	_, warpEnabledChainConfigA := teleporterTestUtils.InitOffChainMessageChainConfig(
+	_, warpEnabledChainConfigA := utils.InitOffChainMessageChainConfig(
 		networkID,
 		l1AInfo,
 		teleporter.TeleporterRegistryAddress(l1AInfo),
 		newProtocolAddress,
 		2,
 	)
-	_, warpEnabledChainConfigB := teleporterTestUtils.InitOffChainMessageChainConfig(
+	_, warpEnabledChainConfigB := utils.InitOffChainMessageChainConfig(
 		networkID,
 		l1BInfo,
 		teleporter.TeleporterRegistryAddress(l1BInfo),
@@ -91,7 +89,7 @@ func ManualMessage(
 	)
 
 	// Create chain config with off chain messages
-	chainConfigs := make(teleporterTestUtils.ChainConfigMap)
+	chainConfigs := make(utils.ChainConfigMap)
 	chainConfigs.Add(cChainInfo, warpEnabledChainConfigC)
 	chainConfigs.Add(l1BInfo, warpEnabledChainConfigB)
 	chainConfigs.Add(l1AInfo, warpEnabledChainConfigA)
@@ -106,7 +104,7 @@ func ManualMessage(
 	//
 	// Set up relayer config
 	//
-	relayerConfig := testUtils.CreateDefaultRelayerConfig(
+	relayerConfig := utils.CreateDefaultRelayerConfig(
 		log,
 		teleporter,
 		[]interfaces.L1TestInfo{cChainInfo},
@@ -114,14 +112,14 @@ func ManualMessage(
 		fundedAddress,
 		relayerKey,
 	)
-	relayerConfigPath := testUtils.WriteRelayerConfig(
+	relayerConfigPath := utils.WriteRelayerConfig(
 		log,
 		relayerConfig,
-		testUtils.DefaultRelayerCfgFname,
+		utils.DefaultRelayerCfgFname,
 	)
 
 	log.Info("Starting the relayer")
-	relayerCleanup, readyChan := testUtils.RunRelayerExecutable(
+	relayerCleanup, readyChan := utils.RunRelayerExecutable(
 		ctx,
 		log,
 		relayerConfigPath,
@@ -133,7 +131,7 @@ func ManualMessage(
 	log.Info("Waiting for the relayer to start up")
 	startupCtx, startupCancel := context.WithTimeout(ctx, 15*time.Second)
 	defer startupCancel()
-	testUtils.WaitForChannelClose(startupCtx, readyChan)
+	utils.WaitForChannelClose(startupCtx, readyChan)
 
 	reqBody := api.ManualWarpMessageRequest{
 		UnsignedMessageBytes: unsignedMessage.Bytes(),

--- a/icm-contracts/tests/flows/services/relay_message_api.go
+++ b/icm-contracts/tests/flows/services/relay_message_api.go
@@ -18,8 +18,6 @@ import (
 	"github.com/ava-labs/icm-services/icm-contracts/tests/interfaces"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/network"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/utils"
-	teleporterTestUtils "github.com/ava-labs/icm-services/icm-contracts/tests/utils"
-	testUtils "github.com/ava-labs/icm-services/icm-contracts/tests/utils"
 	"github.com/ava-labs/icm-services/relayer/api"
 	ethereum "github.com/ava-labs/libevm"
 	"github.com/ava-labs/libevm/common"
@@ -38,16 +36,16 @@ func RelayMessageAPI(
 	l1AInfo := network.GetPrimaryNetworkInfo()
 	l1BInfo, _ := network.GetTwoL1s()
 	fundedAddress, fundedKey := network.GetFundedAccountInfo()
-	err := testUtils.ClearRelayerStorage()
+	err := utils.ClearRelayerStorage()
 	Expect(err).Should(BeNil())
 
 	log.Info("Funding relayer address on all subnets")
 	relayerKey, err := crypto.GenerateKey()
 	Expect(err).Should(BeNil())
-	testUtils.FundRelayers(ctx, []interfaces.L1TestInfo{l1AInfo, l1BInfo}, fundedKey, relayerKey)
+	utils.FundRelayers(ctx, []interfaces.L1TestInfo{l1AInfo, l1BInfo}, fundedKey, relayerKey)
 
 	log.Info("Sending teleporter message")
-	receipt, _, teleporterMessageID := testUtils.SendBasicTeleporterMessage(
+	receipt, _, teleporterMessageID := utils.SendBasicTeleporterMessage(
 		ctx,
 		log,
 		teleporter,
@@ -59,7 +57,7 @@ func RelayMessageAPI(
 	warpMessage := getWarpMessageFromLog(ctx, log, receipt, l1AInfo)
 
 	// Set up relayer config
-	relayerConfig := testUtils.CreateDefaultRelayerConfig(
+	relayerConfig := utils.CreateDefaultRelayerConfig(
 		log,
 		teleporter,
 		[]interfaces.L1TestInfo{l1AInfo, l1BInfo},
@@ -70,14 +68,14 @@ func RelayMessageAPI(
 	// Don't process missed blocks, so we can manually relay
 	relayerConfig.ProcessMissedBlocks = false
 
-	relayerConfigPath := testUtils.WriteRelayerConfig(
+	relayerConfigPath := utils.WriteRelayerConfig(
 		log,
 		relayerConfig,
-		testUtils.DefaultRelayerCfgFname,
+		utils.DefaultRelayerCfgFname,
 	)
 
 	log.Info("Starting the relayer")
-	relayerCleanup, readyChan := testUtils.RunRelayerExecutable(
+	relayerCleanup, readyChan := utils.RunRelayerExecutable(
 		ctx,
 		log,
 		relayerConfigPath,
@@ -89,7 +87,7 @@ func RelayMessageAPI(
 	log.Info("Waiting for the relayer to start up")
 	startupCtx, startupCancel := context.WithTimeout(ctx, 15*time.Second)
 	defer startupCancel()
-	testUtils.WaitForChannelClose(startupCtx, readyChan)
+	utils.WaitForChannelClose(startupCtx, readyChan)
 
 	reqBody := api.RelayMessageRequest{
 		BlockchainID: l1AInfo.BlockchainID.String(),
@@ -127,7 +125,7 @@ func RelayMessageAPI(
 
 		receipt, err := l1BInfo.RPCClient.TransactionReceipt(ctx, common.HexToHash(response.TransactionHash))
 		Expect(err).Should(BeNil())
-		receiveEvent, err := teleporterTestUtils.GetEventFromLogs(
+		receiveEvent, err := utils.GetEventFromLogs(
 			receipt.Logs,
 			teleporter.TeleporterMessenger(l1BInfo).ParseReceiveCrossChainMessage,
 		)

--- a/icm-contracts/tests/flows/services/shared_db.go
+++ b/icm-contracts/tests/flows/services/shared_db.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ava-labs/icm-services/icm-contracts/tests/interfaces"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/network"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/utils"
-	testUtils "github.com/ava-labs/icm-services/icm-contracts/tests/utils"
 	"github.com/ava-labs/libevm/crypto"
 	. "github.com/onsi/gomega"
 )
@@ -25,7 +24,7 @@ func SharedDatabaseAccess(
 	l1AInfo := network.GetPrimaryNetworkInfo()
 	l1BInfo, _ := network.GetTwoL1s()
 	fundedAddress, fundedKey := network.GetFundedAccountInfo()
-	err := testUtils.ClearRelayerStorage()
+	err := utils.ClearRelayerStorage()
 	Expect(err).Should(BeNil())
 
 	//
@@ -38,14 +37,14 @@ func SharedDatabaseAccess(
 	relayerKeyB, err := crypto.GenerateKey()
 	Expect(err).Should(BeNil())
 
-	testUtils.FundRelayers(ctx, []interfaces.L1TestInfo{l1AInfo, l1BInfo}, fundedKey, relayerKeyA)
-	testUtils.FundRelayers(ctx, []interfaces.L1TestInfo{l1AInfo, l1BInfo}, fundedKey, relayerKeyB)
+	utils.FundRelayers(ctx, []interfaces.L1TestInfo{l1AInfo, l1BInfo}, fundedKey, relayerKeyA)
+	utils.FundRelayers(ctx, []interfaces.L1TestInfo{l1AInfo, l1BInfo}, fundedKey, relayerKeyB)
 
 	//
 	// Set up relayer config
 	//
 	// Relayer A will relay messages from Subnet A to Subnet B
-	relayerConfigA := testUtils.CreateDefaultRelayerConfig(
+	relayerConfigA := utils.CreateDefaultRelayerConfig(
 		log,
 		teleporter,
 		[]interfaces.L1TestInfo{l1AInfo},
@@ -54,7 +53,7 @@ func SharedDatabaseAccess(
 		relayerKeyA,
 	)
 	// Relayer B will relay messages from Subnet B to Subnet A
-	relayerConfigB := testUtils.CreateDefaultRelayerConfig(
+	relayerConfigB := utils.CreateDefaultRelayerConfig(
 		log,
 		teleporter,
 		[]interfaces.L1TestInfo{l1BInfo},
@@ -65,12 +64,12 @@ func SharedDatabaseAccess(
 	relayerConfigB.APIPort = 8081
 	relayerConfigB.MetricsPort = 9091
 
-	relayerConfigPathA := testUtils.WriteRelayerConfig(
+	relayerConfigPathA := utils.WriteRelayerConfig(
 		log,
 		relayerConfigA,
 		relayerCfgFnameA,
 	)
-	relayerConfigPathB := testUtils.WriteRelayerConfig(
+	relayerConfigPathB := utils.WriteRelayerConfig(
 		log,
 		relayerConfigB,
 		relayerCfgFnameB,
@@ -82,14 +81,14 @@ func SharedDatabaseAccess(
 	log.Info("Test Relaying from Subnet A to Subnet B")
 
 	log.Info("Starting the relayers")
-	relayerCleanupA, readyChanA := testUtils.RunRelayerExecutable(
+	relayerCleanupA, readyChanA := utils.RunRelayerExecutable(
 		ctx,
 		log,
 		relayerConfigPathA,
 		relayerConfigA,
 	)
 	defer relayerCleanupA()
-	relayerCleanupB, readyChanB := testUtils.RunRelayerExecutable(
+	relayerCleanupB, readyChanB := utils.RunRelayerExecutable(
 		ctx,
 		log,
 		relayerConfigPathB,
@@ -110,7 +109,7 @@ func SharedDatabaseAccess(
 	wg.Wait()
 
 	log.Info("Sending transaction from Subnet A to Subnet B")
-	testUtils.RelayBasicMessage(
+	utils.RelayBasicMessage(
 		ctx,
 		log,
 		teleporter,
@@ -124,7 +123,7 @@ func SharedDatabaseAccess(
 	// Test Relaying from Subnet B to Subnet A
 	//
 	log.Info("Test Relaying from Subnet B to Subnet A")
-	testUtils.RelayBasicMessage(
+	utils.RelayBasicMessage(
 		ctx,
 		log,
 		teleporter,
@@ -138,7 +137,7 @@ func SharedDatabaseAccess(
 
 	// Test processing missed blocks on both relayers.
 	log.Info("Testing processing missed blocks on Subnet A")
-	testUtils.TriggerProcessMissedBlocks(
+	utils.TriggerProcessMissedBlocks(
 		ctx,
 		log,
 		teleporter,
@@ -151,7 +150,7 @@ func SharedDatabaseAccess(
 	)
 
 	log.Info("Testing processing missed blocks on Subnet B")
-	testUtils.TriggerProcessMissedBlocks(
+	utils.TriggerProcessMissedBlocks(
 		ctx,
 		log,
 		teleporter,

--- a/icm-contracts/tests/flows/services/signature_aggregator_api.go
+++ b/icm-contracts/tests/flows/services/signature_aggregator_api.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ava-labs/icm-services/icm-contracts/tests/interfaces"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/network"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/utils"
-	testUtils "github.com/ava-labs/icm-services/icm-contracts/tests/utils"
 	"github.com/ava-labs/icm-services/signature-aggregator/api"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
@@ -44,20 +43,20 @@ func SignatureAggregatorAPI(
 	l1BInfo, _ := network.GetTwoL1s()
 	fundedAddress, fundedKey := network.GetFundedAccountInfo()
 
-	signatureAggregatorConfig := testUtils.CreateDefaultSignatureAggregatorConfig(
+	signatureAggregatorConfig := utils.CreateDefaultSignatureAggregatorConfig(
 		log,
 		[]interfaces.L1TestInfo{l1AInfo, l1BInfo},
 	)
 
-	signatureAggregatorConfigPath := testUtils.WriteSignatureAggregatorConfig(
+	signatureAggregatorConfigPath := utils.WriteSignatureAggregatorConfig(
 		log,
 		signatureAggregatorConfig,
-		testUtils.DefaultSignatureAggregatorCfgFname,
+		utils.DefaultSignatureAggregatorCfgFname,
 	)
 	log.Info("Starting the signature aggregator",
 		zap.String("configPath", signatureAggregatorConfigPath),
 	)
-	signatureAggregatorCancel, readyChan := testUtils.RunSignatureAggregatorExecutable(
+	signatureAggregatorCancel, readyChan := utils.RunSignatureAggregatorExecutable(
 		ctx,
 		log,
 		signatureAggregatorConfigPath,
@@ -69,13 +68,13 @@ func SignatureAggregatorAPI(
 	log.Info("Waiting for the relayer to start up")
 	startupCtx, startupCancel := context.WithTimeout(ctx, 15*time.Second)
 	defer startupCancel()
-	testUtils.WaitForChannelClose(startupCtx, readyChan)
+	utils.WaitForChannelClose(startupCtx, readyChan)
 
 	// End setup step
 	// Begin Test Case 1
 
 	log.Info("Sending teleporter message from A -> B")
-	receipt, _, _ := testUtils.SendBasicTeleporterMessage(
+	receipt, _, _ := utils.SendBasicTeleporterMessage(
 		ctx,
 		log,
 		teleporter,
@@ -130,7 +129,7 @@ func SignatureAggregatorAPI(
 
 	// Try in the other direction
 	log.Info("Sending teleporter message from B -> A")
-	receipt, _, _ = testUtils.SendBasicTeleporterMessage(
+	receipt, _, _ = utils.SendBasicTeleporterMessage(
 		ctx,
 		log,
 		teleporter,

--- a/icm-contracts/tests/flows/services/signature_aggregator_epoch_api.go
+++ b/icm-contracts/tests/flows/services/signature_aggregator_epoch_api.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ava-labs/icm-services/icm-contracts/tests/interfaces"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/network"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/utils"
-	testUtils "github.com/ava-labs/icm-services/icm-contracts/tests/utils"
 	"github.com/ava-labs/icm-services/signature-aggregator/api"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
@@ -52,20 +51,20 @@ func SignatureAggregatorEpochAPI(
 	l1BInfo, _ := network.GetTwoL1s()
 	fundedAddress, fundedKey := network.GetFundedAccountInfo()
 
-	signatureAggregatorConfig := testUtils.CreateDefaultSignatureAggregatorConfig(
+	signatureAggregatorConfig := utils.CreateDefaultSignatureAggregatorConfig(
 		log,
 		[]interfaces.L1TestInfo{l1AInfo, l1BInfo},
 	)
 
-	signatureAggregatorConfigPath := testUtils.WriteSignatureAggregatorConfig(
+	signatureAggregatorConfigPath := utils.WriteSignatureAggregatorConfig(
 		log,
 		signatureAggregatorConfig,
-		testUtils.DefaultSignatureAggregatorCfgFname,
+		utils.DefaultSignatureAggregatorCfgFname,
 	)
 	log.Info("Starting the signature aggregator for epoch tests",
 		zap.String("configPath", signatureAggregatorConfigPath),
 	)
-	signatureAggregatorCancel, readyChan := testUtils.RunSignatureAggregatorExecutable(
+	signatureAggregatorCancel, readyChan := utils.RunSignatureAggregatorExecutable(
 		ctx,
 		log,
 		signatureAggregatorConfigPath,
@@ -77,12 +76,12 @@ func SignatureAggregatorEpochAPI(
 	log.Info("Waiting for the signature aggregator to start up")
 	startupCtx, startupCancel := context.WithTimeout(ctx, 15*time.Second)
 	defer startupCancel()
-	testUtils.WaitForChannelClose(startupCtx, readyChan)
+	utils.WaitForChannelClose(startupCtx, readyChan)
 
 	// End setup step
 
 	log.Info("Sending teleporter message for epoch validator tests")
-	receipt, _, _ := testUtils.SendBasicTeleporterMessage(
+	receipt, _, _ := utils.SendBasicTeleporterMessage(
 		ctx,
 		log,
 		teleporter,
@@ -151,7 +150,7 @@ func SignatureAggregatorEpochAPI(
 
 	// Test the reverse direction as well
 	log.Info("Testing reverse direction with epoch validators")
-	receipt, _, _ = testUtils.SendBasicTeleporterMessage(
+	receipt, _, _ = utils.SendBasicTeleporterMessage(
 		ctx,
 		log,
 		teleporter,

--- a/icm-contracts/tests/flows/services/validators_only_network.go
+++ b/icm-contracts/tests/flows/services/validators_only_network.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ava-labs/icm-services/icm-contracts/tests/interfaces"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/network"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/utils"
-	testUtils "github.com/ava-labs/icm-services/icm-contracts/tests/utils"
 	"github.com/ava-labs/icm-services/peers/clients"
 	"github.com/ava-labs/icm-services/signature-aggregator/api"
 	. "github.com/onsi/gomega"
@@ -68,14 +67,14 @@ func ValidatorsOnlyNetwork(
 	Expect(err).Should(BeNil())
 
 	// Create a config without TLS cert and key
-	baseConfig := testUtils.CreateDefaultSignatureAggregatorConfig(
+	baseConfig := utils.CreateDefaultSignatureAggregatorConfig(
 		log,
 		[]interfaces.L1TestInfo{l1AInfo, l1BInfo},
 	)
-	baseConfigPath := testUtils.WriteSignatureAggregatorConfig(
+	baseConfigPath := utils.WriteSignatureAggregatorConfig(
 		log,
 		baseConfig,
-		testUtils.DefaultSignatureAggregatorCfgFname,
+		utils.DefaultSignatureAggregatorCfgFname,
 	)
 
 	keyPath := dir + "/key.pem"
@@ -86,15 +85,15 @@ func ValidatorsOnlyNetwork(
 	signatureAggregatorConfig.TLSCertPath = certPath
 	signatureAggregatorConfig.TLSKeyPath = keyPath
 
-	signatureAggregatorConfigPath := testUtils.WriteSignatureAggregatorConfig(
+	signatureAggregatorConfigPath := utils.WriteSignatureAggregatorConfig(
 		log,
 		signatureAggregatorConfig,
-		testUtils.DefaultSignatureAggregatorCfgFname,
+		utils.DefaultSignatureAggregatorCfgFname,
 	)
 	log.Info("Starting the signature aggregator",
 		zap.String("configPath", signatureAggregatorConfigPath),
 	)
-	signatureAggregatorCancel, readyChan := testUtils.RunSignatureAggregatorExecutable(
+	signatureAggregatorCancel, readyChan := utils.RunSignatureAggregatorExecutable(
 		ctx,
 		log,
 		signatureAggregatorConfigPath,
@@ -105,7 +104,7 @@ func ValidatorsOnlyNetwork(
 	log.Info("Waiting for the signature-aggregator to start up")
 	startupCtx, startupCancel := context.WithTimeout(ctx, 15*time.Second)
 	defer startupCancel()
-	testUtils.WaitForChannelClose(startupCtx, readyChan)
+	utils.WaitForChannelClose(startupCtx, readyChan)
 
 	cert, err := staking.LoadTLSCertFromFiles(keyPath, certPath)
 	Expect(err).Should(BeNil())
@@ -119,7 +118,7 @@ func ValidatorsOnlyNetwork(
 	// We have to send the message before making the network private.
 
 	log.Info("Sending teleporter message from B -> A")
-	receipt, _, _ := testUtils.SendBasicTeleporterMessage(
+	receipt, _, _ := utils.SendBasicTeleporterMessage(
 		ctx,
 		log,
 		teleporter,
@@ -220,7 +219,7 @@ func ValidatorsOnlyNetwork(
 
 	// start sig-agg again with a floating TLS cert - this should fail
 	log.Info("Starting the signature aggregator with a floating TLS cert")
-	signatureAggregatorCancel, readyChan = testUtils.RunSignatureAggregatorExecutable(
+	signatureAggregatorCancel, readyChan = utils.RunSignatureAggregatorExecutable(
 		ctx,
 		log,
 		baseConfigPath,
@@ -231,14 +230,14 @@ func ValidatorsOnlyNetwork(
 	log.Info("Waiting for the signature-aggregator to start up")
 	startupCtx, startupCancel = context.WithTimeout(ctx, 15*time.Second)
 	defer startupCancel()
-	testUtils.WaitForChannelClose(startupCtx, readyChan)
+	utils.WaitForChannelClose(startupCtx, readyChan)
 
 	sendRequestToAPI(false)
 	signatureAggregatorCancel()
 
 	// start sig-agg again with the same TLS cert
 	log.Info("Starting the signature aggregator with the same TLS cert")
-	signatureAggregatorCancel, readyChan = testUtils.RunSignatureAggregatorExecutable(
+	signatureAggregatorCancel, readyChan = utils.RunSignatureAggregatorExecutable(
 		ctx,
 		log,
 		signatureAggregatorConfigPath,
@@ -250,7 +249,7 @@ func ValidatorsOnlyNetwork(
 	log.Info("Waiting for the signature-aggregator to start up")
 	startupCtx, startupCancel = context.WithTimeout(ctx, 15*time.Second)
 	defer startupCancel()
-	testUtils.WaitForChannelClose(startupCtx, readyChan)
+	utils.WaitForChannelClose(startupCtx, readyChan)
 
 	sendRequestToAPI(true)
 }

--- a/icm-contracts/tests/flows/services/warp_api.go
+++ b/icm-contracts/tests/flows/services/warp_api.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ava-labs/icm-services/icm-contracts/tests/interfaces"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/network"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/utils"
-	testUtils "github.com/ava-labs/icm-services/icm-contracts/tests/utils"
 	"github.com/ava-labs/libevm/crypto"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
@@ -39,7 +38,7 @@ func WarpAPIRelay(
 	l1AInfo := network.GetPrimaryNetworkInfo()
 	l1BInfo, _ := network.GetTwoL1s()
 	fundedAddress, fundedKey := network.GetFundedAccountInfo()
-	err := testUtils.ClearRelayerStorage()
+	err := utils.ClearRelayerStorage()
 	Expect(err).Should(BeNil())
 
 	//
@@ -49,12 +48,12 @@ func WarpAPIRelay(
 	log.Info("Funding relayer address on all subnets")
 	relayerKey, err := crypto.GenerateKey()
 	Expect(err).Should(BeNil())
-	testUtils.FundRelayers(ctx, []interfaces.L1TestInfo{l1AInfo, l1BInfo}, fundedKey, relayerKey)
+	utils.FundRelayers(ctx, []interfaces.L1TestInfo{l1AInfo, l1BInfo}, fundedKey, relayerKey)
 
 	//
 	// Set up relayer config
 	//
-	relayerConfig := testUtils.CreateDefaultRelayerConfig(
+	relayerConfig := utils.CreateDefaultRelayerConfig(
 		log,
 		teleporter,
 		[]interfaces.L1TestInfo{l1AInfo, l1BInfo},
@@ -67,7 +66,7 @@ func WarpAPIRelay(
 		subnet.WarpAPIEndpoint = subnet.RPCEndpoint
 	}
 
-	relayerConfigPath := testUtils.WriteRelayerConfig(log, relayerConfig, testUtils.DefaultRelayerCfgFname)
+	relayerConfigPath := utils.WriteRelayerConfig(log, relayerConfig, utils.DefaultRelayerCfgFname)
 
 	//
 	// Test Relaying from Subnet A to Subnet B
@@ -75,7 +74,7 @@ func WarpAPIRelay(
 	log.Info("Test Relaying from Subnet A to Subnet B")
 
 	log.Info("Starting the relayer")
-	relayerCleanup, readyChan := testUtils.RunRelayerExecutable(
+	relayerCleanup, readyChan := utils.RunRelayerExecutable(
 		ctx,
 		log,
 		relayerConfigPath,
@@ -87,10 +86,10 @@ func WarpAPIRelay(
 	log.Info("Waiting for the relayer to start up")
 	startupCtx, startupCancel := context.WithTimeout(ctx, 15*time.Second)
 	defer startupCancel()
-	testUtils.WaitForChannelClose(startupCtx, readyChan)
+	utils.WaitForChannelClose(startupCtx, readyChan)
 
 	log.Info("Sending transaction from Subnet A to Subnet B")
-	testUtils.RelayBasicMessage(
+	utils.RelayBasicMessage(
 		ctx,
 		log,
 		teleporter,
@@ -104,7 +103,7 @@ func WarpAPIRelay(
 	// Test Relaying from Subnet B to Subnet A
 	//
 	log.Info("Test Relaying from Subnet B to Subnet A")
-	testUtils.RelayBasicMessage(
+	utils.RelayBasicMessage(
 		ctx,
 		log,
 		teleporter,

--- a/icm-contracts/tests/suites/services/services_suite_test.go
+++ b/icm-contracts/tests/suites/services/services_suite_test.go
@@ -21,9 +21,8 @@ import (
 	"github.com/ava-labs/avalanchego/utils/units"
 	servicesFlows "github.com/ava-labs/icm-services/icm-contracts/tests/flows/services"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/network"
-	teleporterTestUtils "github.com/ava-labs/icm-services/icm-contracts/tests/utils"
-	testUtils "github.com/ava-labs/icm-services/icm-contracts/tests/utils"
-	"github.com/ava-labs/icm-services/utils"
+	"github.com/ava-labs/icm-services/icm-contracts/tests/utils"
+	globalUtils "github.com/ava-labs/icm-services/utils"
 	"github.com/ava-labs/libevm/common"
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -41,7 +40,7 @@ var (
 	log logging.Logger
 
 	localNetworkInstance *network.LocalNetwork
-	teleporterInfo       teleporterTestUtils.TeleporterTestInfo
+	teleporterInfo       utils.TeleporterTestInfo
 
 	decider  *exec.Cmd
 	cancelFn context.CancelFunc
@@ -88,23 +87,23 @@ var _ = ginkgo.BeforeSuite(func(ctx context.Context) {
 	)
 
 	log.Info("Building all ICM service executables")
-	testUtils.BuildAllExecutables(ctx, log)
+	utils.BuildAllExecutables(ctx, log)
 
 	// Generate the Teleporter deployment values
 	teleporterContractAddress := common.HexToAddress(
-		testUtils.ReadHexTextFile("./tests/utils/UniversalTeleporterMessengerContractAddress.txt"),
+		utils.ReadHexTextFile("./tests/utils/UniversalTeleporterMessengerContractAddress.txt"),
 	)
 	teleporterDeployerAddress := common.HexToAddress(
-		testUtils.ReadHexTextFile("./tests/utils/UniversalTeleporterDeployerAddress.txt"),
+		utils.ReadHexTextFile("./tests/utils/UniversalTeleporterDeployerAddress.txt"),
 	)
-	teleporterDeployedByteCode := testUtils.ReadHexTextFile(
+	teleporterDeployedByteCode := utils.ReadHexTextFile(
 		"./tests/utils/UniversalTeleporterDeployedBytecode.txt",
 	)
-	teleporterDeployerTransactionStr := testUtils.ReadHexTextFile(
+	teleporterDeployerTransactionStr := utils.ReadHexTextFile(
 		"./tests/utils/UniversalTeleporterDeployerTransaction.txt",
 	)
 	teleporterDeployerTransaction, err := hex.DecodeString(
-		utils.SanitizeHexString(teleporterDeployerTransactionStr),
+		globalUtils.SanitizeHexString(teleporterDeployerTransactionStr),
 	)
 	Expect(err).Should(BeNil())
 	networkStartCtx, networkStartCancel := context.WithTimeout(ctx, 240*2*time.Second)
@@ -137,7 +136,7 @@ var _ = ginkgo.BeforeSuite(func(ctx context.Context) {
 		4,
 		e2eFlags,
 	)
-	teleporterInfo = teleporterTestUtils.NewTeleporterTestInfo(localNetworkInstance.GetAllL1Infos())
+	teleporterInfo = utils.NewTeleporterTestInfo(localNetworkInstance.GetAllL1Infos())
 
 	// Only need to deploy Teleporter on the C-Chain since it is included in the genesis of the subnet chains.
 	_, fundedKey := localNetworkInstance.GetFundedAccountInfo()
@@ -162,7 +161,7 @@ var _ = ginkgo.BeforeSuite(func(ctx context.Context) {
 		localNetworkInstance.ConvertSubnet(
 			networkStartCtx,
 			subnet,
-			teleporterTestUtils.PoAValidatorManager,
+			utils.PoAValidatorManager,
 			[]uint64{units.Schmeckle, units.Schmeckle, units.Schmeckle, units.Schmeckle},
 			[]uint64{defaultBalance, defaultBalance, defaultBalance, minimumL1ValidatorBalance - 1},
 			fundedKey,


### PR DESCRIPTION
## Why this should be merged
We were importing the same package 2 or 3 times under different aliases, probably due to consolidating the testing utils.

## How this works

## How this was tested

## How is this documented