### PR TITLE
Sort imports, lint script autofixes

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -26,7 +26,10 @@ jobs:
           go-version-file: 'go.mod'
 
     - name: Run Lint
-      run: ./scripts/lint.sh --go-lint
+      run: |
+        ./scripts/lint.sh --go-lint
+        git --no-pager diff -- **.go
+        git --no-pager diff --quiet -- **.go
 
   protobuf-check:
     runs-on: ubuntu-22.04

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - unused
     - whitespace
     - lll
+    - gci
 
 linters-settings:
   gofmt:

--- a/abi-bindings/go/packer/packer_test.go
+++ b/abi-bindings/go/packer/packer_test.go
@@ -16,7 +16,6 @@ import (
 	validatorsetsig "github.com/ava-labs/icm-services/abi-bindings/go/governance/ValidatorSetSig"
 	teleportermessenger "github.com/ava-labs/icm-services/abi-bindings/go/teleporter/TeleporterMessenger"
 	teleporterregistry "github.com/ava-labs/icm-services/abi-bindings/go/teleporter/registry/TeleporterRegistry"
-
 	"github.com/stretchr/testify/require"
 	"golang.org/x/tools/go/packages"
 )

--- a/icm-contracts/tests/flows/ictt/native_home_erc20_remote_multihop.go
+++ b/icm-contracts/tests/flows/ictt/native_home_erc20_remote_multihop.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ava-labs/icm-services/icm-contracts/tests/utils"
 	"github.com/ava-labs/libevm/crypto"
 	"github.com/ava-labs/subnet-evm/accounts/abi/bind"
-
 	. "github.com/onsi/gomega"
 )
 

--- a/icm-contracts/tests/flows/teleporter/registry/check_upgrade_access.go
+++ b/icm-contracts/tests/flows/teleporter/registry/check_upgrade_access.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ava-labs/icm-services/icm-contracts/tests/utils"
 	"github.com/ava-labs/libevm/crypto"
 	"github.com/ava-labs/subnet-evm/accounts/abi/bind"
-
 	. "github.com/onsi/gomega"
 )
 

--- a/icm-contracts/tests/flows/teleporter/relay_message_twice.go
+++ b/icm-contracts/tests/flows/teleporter/relay_message_twice.go
@@ -10,9 +10,8 @@ import (
 	"github.com/ava-labs/icm-services/log"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/subnet-evm/accounts/abi/bind"
-	"go.uber.org/zap"
-
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
 )
 
 func RelayMessageTwice(

--- a/icm-contracts/tests/flows/validator-manager/poa_to_pos.go
+++ b/icm-contracts/tests/flows/validator-manager/poa_to_pos.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ava-labs/icm-services/icm-contracts/tests/utils"
 	"github.com/ava-labs/libevm/crypto"
 	"github.com/ava-labs/subnet-evm/accounts/abi/bind"
-
 	. "github.com/onsi/gomega"
 )
 

--- a/icm-contracts/tests/network/network.go
+++ b/icm-contracts/tests/network/network.go
@@ -32,15 +32,14 @@ import (
 	validatormanager "github.com/ava-labs/icm-services/abi-bindings/go/validator-manager/ValidatorManager"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/interfaces"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/utils"
-	"github.com/ava-labs/subnet-evm/accounts/abi/bind"
-	"github.com/ava-labs/subnet-evm/ethclient"
-	subnetEvmTestUtils "github.com/ava-labs/subnet-evm/tests/utils"
-	"go.uber.org/zap"
-
 	"github.com/ava-labs/icm-services/log"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/crypto"
+	"github.com/ava-labs/subnet-evm/accounts/abi/bind"
+	"github.com/ava-labs/subnet-evm/ethclient"
+	subnetEvmTestUtils "github.com/ava-labs/subnet-evm/tests/utils"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
 )
 
 type ProxyAddress struct {

--- a/icm-contracts/tests/utils/ictt.go
+++ b/icm-contracts/tests/utils/ictt.go
@@ -26,9 +26,8 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/crypto"
 	"github.com/ava-labs/subnet-evm/accounts/abi/bind"
-	"go.uber.org/zap"
-
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
 )
 
 // Deployer keys set in the genesis file in order to determine the deployed address in advance.

--- a/icm-contracts/tests/utils/signature_aggregator.go
+++ b/icm-contracts/tests/utils/signature_aggregator.go
@@ -19,9 +19,8 @@ import (
 	"github.com/ava-labs/avalanchego/vms/proposervm"
 	"github.com/ava-labs/icm-services/icm-contracts/tests/interfaces"
 	"github.com/ava-labs/icm-services/log"
-	"go.uber.org/zap"
-
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
 )
 
 const (

--- a/icm-contracts/tests/utils/token_scaling.go
+++ b/icm-contracts/tests/utils/token_scaling.go
@@ -8,7 +8,6 @@ import (
 	nativetokenhome "github.com/ava-labs/icm-services/abi-bindings/go/ictt/TokenHome/NativeTokenHome"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/subnet-evm/accounts/abi/bind"
-
 	. "github.com/onsi/gomega"
 )
 

--- a/icm-contracts/tests/utils/validator_manager.go
+++ b/icm-contracts/tests/utils/validator_manager.go
@@ -37,10 +37,9 @@ import (
 	"github.com/ava-labs/subnet-evm/precompile/contracts/warp"
 	subnetEvmUtils "github.com/ava-labs/subnet-evm/tests/utils"
 	"github.com/ava-labs/subnet-evm/warp/messages"
+	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
-
-	. "github.com/onsi/gomega"
 )
 
 const (

--- a/peers/app_request_network.go
+++ b/peers/app_request_network.go
@@ -31,12 +31,11 @@ import (
 	"github.com/ava-labs/avalanchego/utils/sampler"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/platformvm"
+	"github.com/ava-labs/icm-services/peers/clients"
+	sharedUtils "github.com/ava-labs/icm-services/utils"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/warp"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
-
-	"github.com/ava-labs/icm-services/peers/clients"
-	sharedUtils "github.com/ava-labs/icm-services/utils"
 )
 
 const (

--- a/peers/clients/validator_client.go
+++ b/peers/clients/validator_client.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/platformvm"
 	pchainapi "github.com/ava-labs/avalanchego/vms/platformvm/api"
-
 	"github.com/ava-labs/icm-services/config"
 )
 

--- a/relayer/application_relayer.go
+++ b/relayer/application_relayer.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	avalancheWarp "github.com/ava-labs/avalanchego/vms/platformvm/warp"
-
 	"github.com/ava-labs/icm-services/database"
 	"github.com/ava-labs/icm-services/messages"
 	"github.com/ava-labs/icm-services/peers"

--- a/relayer/config/config.go
+++ b/relayer/config/config.go
@@ -12,20 +12,17 @@ import (
 	"reflect"
 	"strings"
 
-	basecfg "github.com/ava-labs/icm-services/config"
-	"github.com/ava-labs/icm-services/peers"
-	"go.uber.org/zap"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
-
+	basecfg "github.com/ava-labs/icm-services/config"
+	"github.com/ava-labs/icm-services/peers"
 	"github.com/ava-labs/subnet-evm/ethclient"
 	"github.com/ava-labs/subnet-evm/params"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/warp"
-
 	// Force-load precompiles to trigger registration
 	_ "github.com/ava-labs/subnet-evm/precompile/registry"
+	"go.uber.org/zap"
 )
 
 const (

--- a/relayer/config/viper_test.go
+++ b/relayer/config/viper_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	basecfg "github.com/ava-labs/icm-services/config"
-
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )

--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -36,13 +36,12 @@ import (
 	"github.com/ava-labs/subnet-evm/ethclient"
 	"github.com/ava-labs/subnet-evm/plugin/evm"
 	"go.uber.org/atomic"
+	// Sets GOMAXPROCS to the CPU quota for containerized environments
+	_ "go.uber.org/automaxprocs"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-
-	// Sets GOMAXPROCS to the CPU quota for containerized environments
-	_ "go.uber.org/automaxprocs"
 )
 
 var version = "v0.0.0-dev"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -35,7 +35,7 @@ function solLinter() {
 function golangLinter() {
     echo "Linting Golang code..."
     cd $REPO_PATH
-    go run github.com/golangci/golangci-lint/cmd/golangci-lint run --config=$REPO_PATH/.golangci.yml --build-tags=test ./... --timeout 5m
+    go run github.com/golangci/golangci-lint/cmd/golangci-lint run --config=$REPO_PATH/.golangci.yml --build-tags=test ./... --timeout 5m --fix
     (cd proto && go run github.com/bufbuild/buf/cmd/buf lint)
 }
 

--- a/signature-aggregator/aggregator/aggregator_test.go
+++ b/signature-aggregator/aggregator/aggregator_test.go
@@ -3,11 +3,10 @@ package aggregator
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"slices"
 	"testing"
 	"time"
-
-	"crypto/rand"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/message"

--- a/signature-aggregator/main/main.go
+++ b/signature-aggregator/main/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/vms/platformvm"
-
 	metricsServer "github.com/ava-labs/icm-services/metrics"
 	"github.com/ava-labs/icm-services/peers"
 	"github.com/ava-labs/icm-services/signature-aggregator/aggregator"


### PR DESCRIPTION
## Why this should be merged
Adds the `gci` linter to `golangci-lint`.

`lint.sh` will now autofix problems when running `golangci-lint`, so the github action now looks at the diff instead of relying on the failure status of `lint.sh`.

## How this works

## How this was tested

## How is this documented