### PR TITLE
Unexport vars

### DIFF
--- a/icm-contracts/tests/suites/governance/governance_suite_test.go
+++ b/icm-contracts/tests/suites/governance/governance_suite_test.go
@@ -21,7 +21,7 @@ const (
 )
 
 var (
-	LocalNetworkInstance *localnetwork.LocalNetwork
+	localNetworkInstance *localnetwork.LocalNetwork
 	e2eFlags             *e2e.FlagVars
 )
 
@@ -45,7 +45,7 @@ var _ = ginkgo.BeforeSuite(func(ctx context.Context) {
 	// Create the local network instance
 	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
 	defer cancel()
-	LocalNetworkInstance = localnetwork.NewLocalNetwork(
+	localNetworkInstance = localnetwork.NewLocalNetwork(
 		ctx,
 		"governance-test-local-network",
 		warpGenesisTemplateFile,
@@ -69,8 +69,8 @@ var _ = ginkgo.BeforeSuite(func(ctx context.Context) {
 })
 
 var _ = ginkgo.AfterSuite(func() {
-	LocalNetworkInstance.TearDownNetwork()
-	LocalNetworkInstance = nil
+	localNetworkInstance.TearDownNetwork()
+	localNetworkInstance = nil
 })
 
 var _ = ginkgo.Describe("[Governance integration tests]", func() {
@@ -78,6 +78,6 @@ var _ = ginkgo.Describe("[Governance integration tests]", func() {
 	ginkgo.It("Deliver ValidatorSetSig signed message",
 		ginkgo.Label(validatorSetSigLabel),
 		func(ctx context.Context) {
-			governanceFlows.ValidatorSetSig(ctx, LocalNetworkInstance)
+			governanceFlows.ValidatorSetSig(ctx, localNetworkInstance)
 		})
 })

--- a/icm-contracts/tests/suites/ictt/ictt_suite_test.go
+++ b/icm-contracts/tests/suites/ictt/ictt_suite_test.go
@@ -40,8 +40,8 @@ const (
 )
 
 var (
-	LocalNetworkInstance *localnetwork.LocalNetwork
-	TeleporterInfo       utils.TeleporterTestInfo
+	localNetworkInstance *localnetwork.LocalNetwork
+	teleporterInfo       utils.TeleporterTestInfo
 	e2eFlags             *e2e.FlagVars
 )
 
@@ -77,7 +77,7 @@ var _ = ginkgo.BeforeSuite(func(ctx context.Context) {
 	// Create the local network instance
 	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
 	defer cancel()
-	LocalNetworkInstance = localnetwork.NewLocalNetwork(
+	localNetworkInstance = localnetwork.NewLocalNetwork(
 		ctx,
 		"teleporter-test-local-network",
 		warpGenesisTemplateFile,
@@ -103,31 +103,31 @@ var _ = ginkgo.BeforeSuite(func(ctx context.Context) {
 		2,
 		e2eFlags,
 	)
-	TeleporterInfo = utils.NewTeleporterTestInfo(LocalNetworkInstance.GetAllL1Infos())
+	teleporterInfo = utils.NewTeleporterTestInfo(localNetworkInstance.GetAllL1Infos())
 	log.Info("Started local network")
 
 	// Only need to deploy Teleporter on the C-Chain since it is included in the genesis of the L1 chains.
-	_, fundedKey := LocalNetworkInstance.GetFundedAccountInfo()
+	_, fundedKey := localNetworkInstance.GetFundedAccountInfo()
 
 	if e2eFlags.NetworkDir() == "" {
 		// Only deploy Teleporter if we are not reusing an existing network
-		TeleporterInfo.DeployTeleporterMessenger(
+		teleporterInfo.DeployTeleporterMessenger(
 			ctx,
-			LocalNetworkInstance.GetPrimaryNetworkInfo(),
+			localNetworkInstance.GetPrimaryNetworkInfo(),
 			teleporterDeployerTransaction,
 			teleporterDeployerAddress,
 			teleporterContractAddress,
 			fundedKey,
 		)
 
-		for _, l1 := range LocalNetworkInstance.GetAllL1Infos() {
-			TeleporterInfo.SetTeleporter(teleporterContractAddress, l1)
-			TeleporterInfo.InitializeBlockchainID(l1, fundedKey)
-			TeleporterInfo.DeployTeleporterRegistry(l1, fundedKey)
+		for _, l1 := range localNetworkInstance.GetAllL1Infos() {
+			teleporterInfo.SetTeleporter(teleporterContractAddress, l1)
+			teleporterInfo.InitializeBlockchainID(l1, fundedKey)
+			teleporterInfo.DeployTeleporterRegistry(l1, fundedKey)
 		}
 
 		registryAddresseses := make(map[string]string)
-		for l1, teleporterInfo := range TeleporterInfo {
+		for l1, teleporterInfo := range teleporterInfo {
 			registryAddresseses[l1.Hex()] = teleporterInfo.TeleporterRegistryAddress.Hex()
 		}
 
@@ -139,9 +139,9 @@ var _ = ginkgo.BeforeSuite(func(ctx context.Context) {
 	} else {
 		fundAmount := big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(15)) // 11 AVAX
 		fundDeployerTx := utils.CreateNativeTransferTransaction(
-			ctx, LocalNetworkInstance.GetPrimaryNetworkInfo(), fundedKey, teleporterDeployerAddress, fundAmount,
+			ctx, localNetworkInstance.GetPrimaryNetworkInfo(), fundedKey, teleporterDeployerAddress, fundAmount,
 		)
-		utils.SendTransactionAndWaitForSuccess(ctx, LocalNetworkInstance.GetPrimaryNetworkInfo(), fundDeployerTx)
+		utils.SendTransactionAndWaitForSuccess(ctx, localNetworkInstance.GetPrimaryNetworkInfo(), fundDeployerTx)
 		fmt.Println("Deployer funded with", fundAmount, "AVAX")
 
 		// Read the Teleporter registry address from the file
@@ -151,9 +151,9 @@ var _ = ginkgo.BeforeSuite(func(ctx context.Context) {
 		err = json.Unmarshal(data, &registryAddresseses)
 		Expect(err).Should(BeNil())
 
-		for _, l1 := range LocalNetworkInstance.GetAllL1Infos() {
-			TeleporterInfo.SetTeleporter(teleporterContractAddress, l1)
-			TeleporterInfo.SetTeleporterRegistry(
+		for _, l1 := range localNetworkInstance.GetAllL1Infos() {
+			teleporterInfo.SetTeleporter(teleporterContractAddress, l1)
+			teleporterInfo.SetTeleporterRegistry(
 				common.HexToAddress(registryAddresseses[l1.BlockchainID.Hex()]),
 				l1,
 			)
@@ -163,8 +163,8 @@ var _ = ginkgo.BeforeSuite(func(ctx context.Context) {
 })
 
 var _ = ginkgo.AfterSuite(func() {
-	LocalNetworkInstance.TearDownNetwork()
-	LocalNetworkInstance = nil
+	localNetworkInstance.TearDownNetwork()
+	localNetworkInstance = nil
 })
 
 var _ = ginkgo.Describe("[ICTT integration tests]", func() {
@@ -172,56 +172,56 @@ var _ = ginkgo.Describe("[ICTT integration tests]", func() {
 	ginkgo.It("Transfer an ERC20 token between two L1s",
 		ginkgo.Label(icttLabel, erc20TokenHomeLabel, erc20TokenRemoteLabel),
 		func(ctx context.Context) {
-			icttFlows.ERC20TokenHomeERC20TokenRemote(ctx, LocalNetworkInstance, TeleporterInfo)
+			icttFlows.ERC20TokenHomeERC20TokenRemote(ctx, localNetworkInstance, teleporterInfo)
 		})
 	ginkgo.It("Transfer a native token to an ERC20 token",
 		ginkgo.Label(icttLabel, nativeTokenHomeLabel, erc20TokenRemoteLabel),
 		func(ctx context.Context) {
-			icttFlows.NativeTokenHomeERC20TokenRemote(ctx, LocalNetworkInstance, TeleporterInfo)
+			icttFlows.NativeTokenHomeERC20TokenRemote(ctx, localNetworkInstance, teleporterInfo)
 		})
 	ginkgo.It("Transfer a native token to a native token",
 		ginkgo.Label(icttLabel, nativeTokenHomeLabel, nativeTokenRemoteLabel),
 		func(ctx context.Context) {
-			icttFlows.NativeTokenHomeNativeDestination(ctx, LocalNetworkInstance, TeleporterInfo)
+			icttFlows.NativeTokenHomeNativeDestination(ctx, localNetworkInstance, teleporterInfo)
 		})
 	ginkgo.It("Transfer an ERC20 token with ERC20TokenHome multi-hop",
 		ginkgo.Label(icttLabel, erc20TokenHomeLabel, erc20TokenRemoteLabel, multiHopLabel),
 		func(ctx context.Context) {
-			icttFlows.ERC20TokenHomeERC20TokenRemoteMultiHop(ctx, LocalNetworkInstance, TeleporterInfo)
+			icttFlows.ERC20TokenHomeERC20TokenRemoteMultiHop(ctx, localNetworkInstance, teleporterInfo)
 		})
 	ginkgo.It("Transfer a native token with NativeTokenHome multi-hop",
 		ginkgo.Label(icttLabel, nativeTokenHomeLabel, erc20TokenRemoteLabel, multiHopLabel),
 		func(ctx context.Context) {
-			icttFlows.NativeTokenHomeERC20TokenRemoteMultiHop(ctx, LocalNetworkInstance, TeleporterInfo)
+			icttFlows.NativeTokenHomeERC20TokenRemoteMultiHop(ctx, localNetworkInstance, teleporterInfo)
 		})
 	ginkgo.It("Transfer an ERC20 token to a native token",
 		ginkgo.Label(icttLabel, erc20TokenHomeLabel, nativeTokenRemoteLabel),
 		func(ctx context.Context) {
-			icttFlows.ERC20TokenHomeNativeTokenRemote(ctx, LocalNetworkInstance, TeleporterInfo)
+			icttFlows.ERC20TokenHomeNativeTokenRemote(ctx, localNetworkInstance, teleporterInfo)
 		})
 	ginkgo.It("Transfer a native token with ERC20TokenHome multi-hop",
 		ginkgo.Label(icttLabel, erc20TokenHomeLabel, nativeTokenRemoteLabel, multiHopLabel),
 		func(ctx context.Context) {
-			icttFlows.ERC20TokenHomeNativeTokenRemoteMultiHop(ctx, LocalNetworkInstance, TeleporterInfo)
+			icttFlows.ERC20TokenHomeNativeTokenRemoteMultiHop(ctx, localNetworkInstance, teleporterInfo)
 		})
 	ginkgo.It("Transfer a native token to a native token multi-hop",
 		ginkgo.Label(icttLabel, nativeTokenHomeLabel, nativeTokenRemoteLabel, multiHopLabel),
 		func(ctx context.Context) {
-			icttFlows.NativeTokenHomeNativeTokenRemoteMultiHop(ctx, LocalNetworkInstance, TeleporterInfo)
+			icttFlows.NativeTokenHomeNativeTokenRemoteMultiHop(ctx, localNetworkInstance, teleporterInfo)
 		})
 	ginkgo.It("Transfer an ERC20 token using sendAndCall",
 		ginkgo.Label(icttLabel, erc20TokenHomeLabel, erc20TokenRemoteLabel, sendAndCallLabel),
 		func(ctx context.Context) {
-			icttFlows.ERC20TokenHomeERC20TokenRemoteSendAndCall(ctx, LocalNetworkInstance, TeleporterInfo)
+			icttFlows.ERC20TokenHomeERC20TokenRemoteSendAndCall(ctx, localNetworkInstance, teleporterInfo)
 		})
 	ginkgo.It("Registration and collateral checks",
 		ginkgo.Label(icttLabel, erc20TokenHomeLabel, nativeTokenRemoteLabel, registrationLabel),
 		func(ctx context.Context) {
-			icttFlows.RegistrationAndCollateralCheck(ctx, LocalNetworkInstance, TeleporterInfo)
+			icttFlows.RegistrationAndCollateralCheck(ctx, localNetworkInstance, teleporterInfo)
 		})
 	ginkgo.It("Transparent proxy upgrade",
 		ginkgo.Label(icttLabel, erc20TokenHomeLabel, erc20TokenRemoteLabel, upgradabilityLabel),
 		func(ctx context.Context) {
-			icttFlows.TransparentUpgradeableProxy(ctx, LocalNetworkInstance, TeleporterInfo)
+			icttFlows.TransparentUpgradeableProxy(ctx, localNetworkInstance, teleporterInfo)
 		})
 })

--- a/icm-contracts/tests/suites/validator-manager/validator_manager_suite_test.go
+++ b/icm-contracts/tests/suites/validator-manager/validator_manager_suite_test.go
@@ -21,7 +21,7 @@ const (
 )
 
 var (
-	LocalNetworkInstance *localnetwork.LocalNetwork
+	localNetworkInstance *localnetwork.LocalNetwork
 	e2eFlags             *e2e.FlagVars
 )
 
@@ -45,7 +45,7 @@ var _ = ginkgo.BeforeEach(func(ctx context.Context) {
 	// Create the local network instance
 	ctx, cancel := context.WithTimeout(ctx, 240*time.Second)
 	defer cancel()
-	LocalNetworkInstance = localnetwork.NewLocalNetwork(
+	localNetworkInstance = localnetwork.NewLocalNetwork(
 		ctx,
 		"validator-manager-test-local-network",
 		warpGenesisTemplateFile,
@@ -71,8 +71,8 @@ var _ = ginkgo.BeforeEach(func(ctx context.Context) {
 })
 
 var _ = ginkgo.AfterEach(func() {
-	LocalNetworkInstance.TearDownNetwork()
-	LocalNetworkInstance = nil
+	localNetworkInstance.TearDownNetwork()
+	localNetworkInstance = nil
 })
 
 var _ = ginkgo.Describe("[Validator manager integration tests]", func() {
@@ -80,21 +80,21 @@ var _ = ginkgo.Describe("[Validator manager integration tests]", func() {
 	ginkgo.It("Native token staking manager",
 		ginkgo.Label(validatorManagerLabel),
 		func(ctx context.Context) {
-			validatorManagerFlows.NativeTokenStakingManager(ctx, LocalNetworkInstance)
+			validatorManagerFlows.NativeTokenStakingManager(ctx, localNetworkInstance)
 		})
 	ginkgo.It("ERC20 token staking manager",
 		ginkgo.Label(validatorManagerLabel),
 		func(ctx context.Context) {
-			validatorManagerFlows.ERC20TokenStakingManager(ctx, LocalNetworkInstance)
+			validatorManagerFlows.ERC20TokenStakingManager(ctx, localNetworkInstance)
 		})
 	ginkgo.It("PoA migration to PoS",
 		ginkgo.Label(validatorManagerLabel),
 		func(ctx context.Context) {
-			validatorManagerFlows.PoAMigrationToPoS(ctx, LocalNetworkInstance)
+			validatorManagerFlows.PoAMigrationToPoS(ctx, localNetworkInstance)
 		})
 	ginkgo.It("Delegate disable validator",
 		ginkgo.Label(validatorManagerLabel),
 		func(ctx context.Context) {
-			validatorManagerFlows.RemoveDelegatorInactiveValidator(ctx, LocalNetworkInstance)
+			validatorManagerFlows.RemoveDelegatorInactiveValidator(ctx, localNetworkInstance)
 		})
 })


### PR DESCRIPTION
## Why this should be merged
These global vars are only set because we need to set them in `ginkgo.BeforeSuite` and access them in `ginkgo.Describe` or `ginkgo.AfterSuite`. There is no need for any of them to be exported.

## How this works

## How this was tested

## How is this documented