### PR TITLE
Simplify block catchup with uint64

### DIFF
--- a/relayer/listener.go
+++ b/relayer/listener.go
@@ -6,7 +6,6 @@ package relayer
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"math/rand"
 	"time"
 
@@ -137,7 +136,7 @@ func newListener(
 	// Process historical blocks in a separate goroutine so that the main processing loop can
 	// start processing new blocks as soon as possible. Otherwise, it's possible for
 	// ProcessFromHeight to overload the message queue and cause a deadlock.
-	go sub.ProcessFromHeight(big.NewInt(0).SetUint64(startingHeight), lstnr.catchUpResultChan)
+	go sub.ProcessFromHeight(startingHeight, lstnr.catchUpResultChan)
 
 	return &lstnr, nil
 }

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -65,13 +65,8 @@ func NewSubscriber(
 // `MaxBlocksPerRequest`; if processing more than that, multiple eth_getLogs
 // requests will be made.
 // Writes true to the done channel when finished, or false if an error occurs
-func (s *Subscriber) ProcessFromHeight(height *big.Int, done chan bool) {
+func (s *Subscriber) ProcessFromHeight(height uint64, done chan bool) {
 	defer close(done)
-	if height == nil {
-		s.logger.Error("Cannot process logs from nil height")
-		done <- false
-		return
-	}
 
 	// Grab the latest block before filtering logs so we don't miss any before updating the db
 	latestBlockHeightCtx, latestBlockHeightCtxCancel := context.WithTimeout(context.Background(), utils.DefaultRPCTimeout)
@@ -84,23 +79,12 @@ func (s *Subscriber) ProcessFromHeight(height *big.Int, done chan bool) {
 	}
 	s.logger.Info(
 		"Processing historical logs",
-		zap.Uint64("fromBlockHeight", height.Uint64()),
+		zap.Uint64("fromBlockHeight", height),
 		zap.Uint64("latestBlockHeight", latestBlockHeight),
 	)
 
-	bigLatestBlockHeight := big.NewInt(0).SetUint64(latestBlockHeight)
-
-	//nolint:lll
-	for fromBlock := big.NewInt(0).Set(height); fromBlock.Cmp(bigLatestBlockHeight) <= 0; fromBlock.Add(fromBlock, big.NewInt(MaxBlocksPerRequest)) {
-		toBlock := big.NewInt(0).Add(fromBlock, big.NewInt(MaxBlocksPerRequest-1))
-
-		// clamp to latest known block because we've already subscribed
-		// to new blocks and we don't want to double-process any blocks
-		// created after that subscription but before the determination
-		// of this "latest"
-		if toBlock.Cmp(bigLatestBlockHeight) > 0 {
-			toBlock.Set(bigLatestBlockHeight)
-		}
+	for fromBlock := height; fromBlock <= latestBlockHeight; fromBlock += MaxBlocksPerRequest {
+		toBlock := min(fromBlock+MaxBlocksPerRequest-1, latestBlockHeight)
 
 		err = s.processBlockRange(fromBlock, toBlock)
 		if err != nil {
@@ -114,12 +98,12 @@ func (s *Subscriber) ProcessFromHeight(height *big.Int, done chan bool) {
 
 // Process Warp messages from the block range [fromBlock, toBlock], inclusive
 func (s *Subscriber) processBlockRange(
-	fromBlock, toBlock *big.Int,
+	fromBlock, toBlock uint64,
 ) error {
 	s.logger.Info(
 		"Processing block range",
-		zap.Uint64("fromBlockHeight", fromBlock.Uint64()),
-		zap.Uint64("toBlockHeight", toBlock.Uint64()),
+		zap.Uint64("fromBlockHeight", fromBlock),
+		zap.Uint64("toBlockHeight", toBlock),
 	)
 	logs, err := s.getFilterLogsByBlockRangeRetryable(fromBlock, toBlock)
 	if err != nil {
@@ -131,7 +115,7 @@ func (s *Subscriber) processBlockRange(
 		s.logger.Error("Failed to convert logs to blocks", zap.Error(err))
 		return err
 	}
-	for i := fromBlock.Uint64(); i <= toBlock.Uint64(); i++ {
+	for i := fromBlock; i <= toBlock; i++ {
 		if block, ok := blocksWithICMMessages[i]; ok {
 			s.icmBlocks <- block
 		} else {
@@ -145,7 +129,7 @@ func (s *Subscriber) processBlockRange(
 	return nil
 }
 
-func (s *Subscriber) getFilterLogsByBlockRangeRetryable(fromBlock, toBlock *big.Int) ([]types.Log, error) {
+func (s *Subscriber) getFilterLogsByBlockRangeRetryable(fromBlock, toBlock uint64) ([]types.Log, error) {
 	var logs []types.Log
 	operation := func() (err error) {
 		cctx, cancel := context.WithTimeout(context.Background(), utils.DefaultRPCTimeout)
@@ -153,8 +137,8 @@ func (s *Subscriber) getFilterLogsByBlockRangeRetryable(fromBlock, toBlock *big.
 		logs, err = s.rpcClient.FilterLogs(cctx, ethereum.FilterQuery{
 			Topics:    [][]common.Hash{{relayerTypes.WarpPrecompileLogFilter}},
 			Addresses: []common.Address{warp.ContractAddress},
-			FromBlock: fromBlock,
-			ToBlock:   toBlock,
+			FromBlock: new(big.Int).SetUint64(fromBlock),
+			ToBlock:   new(big.Int).SetUint64(toBlock),
 		})
 		return err
 	}

--- a/vms/evm/subscriber_test.go
+++ b/vms/evm/subscriber_test.go
@@ -4,7 +4,6 @@
 package evm
 
 import (
-	"math/big"
 	"testing"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -39,8 +38,8 @@ func makeSubscriberWithMockEthClient(t *testing.T) (*Subscriber, *mock_ethclient
 func TestProcessFromHeight(t *testing.T) {
 	testCases := []struct {
 		name   string
-		latest int64
-		input  int64
+		latest uint64
+		input  uint64
 	}{
 		{
 			name:   "zero to max blocks",
@@ -81,7 +80,7 @@ func TestProcessFromHeight(t *testing.T) {
 			mockEthClient.
 				EXPECT().
 				BlockNumber(gomock.Any()).
-				Return(uint64(tc.latest), nil).
+				Return(tc.latest, nil).
 				Times(1)
 			if tc.latest > tc.input {
 				expectedFilterLogCalls := (tc.latest-tc.input+1)/MaxBlocksPerRequest + 1
@@ -94,14 +93,14 @@ func TestProcessFromHeight(t *testing.T) {
 				).Times(int(expectedFilterLogCalls))
 			}
 			done := make(chan bool, 1)
-			subscriberUnderTest.ProcessFromHeight(big.NewInt(tc.input), done)
+			subscriberUnderTest.ProcessFromHeight(tc.input, done)
 			result := <-done
 			require.True(t, result)
 
 			if tc.latest > tc.input {
 				for i := tc.input; i <= tc.latest; i++ {
 					block := <-subscriberUnderTest.ICMBlocks()
-					require.Equal(t, uint64(i), block.BlockNumber)
+					require.Equal(t, i, block.BlockNumber)
 					require.Empty(t, block.Messages)
 				}
 			}


### PR DESCRIPTION
## Why this should be merged
Simplifies catchup logic to use uint64 until we absolutely need to use `big.Int` to make the logic a lot simpler to follow.

## How this works

## How this was tested

## How is this documented