### PR TITLE
Unify error channel

### DIFF
--- a/relayer/listener.go
+++ b/relayer/listener.go
@@ -32,11 +32,11 @@ type Listener struct {
 	currentRequestID   uint32
 	logger             logging.Logger
 	sourceBlockchain   config.SourceBlockchain
-	catchUpResultChan  chan bool
 	healthStatus       *atomic.Bool
 	ethClient          ethclient.Client
 	messageCoordinator *MessageCoordinator
 	maxConcurrentMsg   uint64
+	errChan            chan error
 }
 
 // RunListener creates a Listener instance and the ApplicationRelayers for a subnet.
@@ -103,15 +103,8 @@ func newListener(
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to node via WS: %w", err)
 	}
-	sub := evm.NewSubscriber(logger, blockchainID, ethWSClient, ethRPCClient)
-
-	// Marks when the listener has finished the catch-up process on startup.
-	// Until that time, we do not know the order in which messages are processed,
-	// since the catch-up process occurs concurrently with normal message processing
-	// via the subscriber's Subscribe method. As a result, we cannot safely write the
-	// latest processed block to the database without risking missing a block in a fault
-	// scenario.
-	catchUpResultChan := make(chan bool, 1)
+	errChan := make(chan error, maxConcurrentMsg)
+	sub := evm.NewSubscriber(logger, blockchainID, ethWSClient, ethRPCClient, errChan)
 
 	logger.Info("Creating relayer")
 	lstnr := Listener{
@@ -119,7 +112,7 @@ func newListener(
 		currentRequestID:   rand.Uint32(), // Initialize to a random value to mitigate requestID collision
 		logger:             logger,
 		sourceBlockchain:   sourceBlockchain,
-		catchUpResultChan:  catchUpResultChan,
+		errChan:            errChan,
 		healthStatus:       relayerHealth,
 		ethClient:          ethRPCClient,
 		messageCoordinator: messageCoordinator,
@@ -136,7 +129,7 @@ func newListener(
 	// Process historical blocks in a separate goroutine so that the main processing loop can
 	// start processing new blocks as soon as possible. Otherwise, it's possible for
 	// ProcessFromHeight to overload the message queue and cause a deadlock.
-	go sub.ProcessFromHeight(startingHeight, lstnr.catchUpResultChan)
+	go sub.ProcessFromHeight(startingHeight)
 
 	return &lstnr, nil
 }
@@ -146,39 +139,18 @@ func newListener(
 // Exits if context is cancelled by another goroutine.
 func (lstnr *Listener) processLogs(ctx context.Context) error {
 	// Error channel for application relayer errors
-	errChan := make(chan error, lstnr.maxConcurrentMsg)
 	for {
 		select {
-		case err := <-errChan:
+		case err := <-lstnr.errChan:
 			lstnr.healthStatus.Store(false)
-			lstnr.logger.Error("Received error from application relayer", zap.Error(err))
-		case catchUpResult, ok := <-lstnr.catchUpResultChan:
-			// As soon as we've received anything on the channel, there are no more values expected.
-			// The expected case is that the channel is closed by the subscriber after writing a value to it,
-			// but we also defensively handle an unexpected close.
-			lstnr.catchUpResultChan = nil
-
-			// Mark the relayer as unhealthy if the catch-up process fails or if the catch-up channel is unexpectedly closed.
-			if !ok {
-				lstnr.healthStatus.Store(false)
-				lstnr.logger.Error("Catch-up channel unexpectedly closed. Exiting listener goroutine.")
-				return fmt.Errorf("catch-up channel unexpectedly closed")
-			}
-			if !catchUpResult {
-				lstnr.healthStatus.Store(false)
-				lstnr.logger.Error("Failed to catch up on historical blocks. Exiting listener goroutine.")
-				return fmt.Errorf("failed to catch up on historical blocks")
-			}
+			lstnr.logger.Error("Listener received error", zap.Error(err))
+			return fmt.Errorf("listener received error: %w", err)
 		case icmBlockInfo := <-lstnr.Subscriber.ICMBlocks():
 			go lstnr.messageCoordinator.ProcessBlock(
 				icmBlockInfo,
 				lstnr.sourceBlockchain.GetBlockchainID(),
-				errChan,
+				lstnr.errChan,
 			)
-		case err := <-lstnr.Subscriber.Err():
-			lstnr.healthStatus.Store(false)
-			lstnr.logger.Error("Error processing logs. Relayer goroutine exiting", zap.Error(err))
-			return fmt.Errorf("error processing logs: %w", err)
 		case subError := <-lstnr.Subscriber.SubscribeErr():
 			lstnr.logger.Info("Received error from subscribed node", zap.Error(subError))
 			subError = lstnr.reconnectToSubscriber()

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -46,6 +46,7 @@ func NewSubscriber(
 	blockchainID ids.ID,
 	wsClient ethclient.Client,
 	rpcClient ethclient.Client,
+	errChan chan error,
 ) *Subscriber {
 	subscriber := &Subscriber{
 		blockchainID: blockchainID,
@@ -54,7 +55,7 @@ func NewSubscriber(
 		logger:       logger,
 		icmBlocks:    make(chan *relayerTypes.WarpBlockInfo, maxClientSubscriptionBuffer),
 		headers:      make(chan *types.Header, maxClientSubscriptionBuffer),
-		errChan:      make(chan error),
+		errChan:      errChan,
 	}
 	go subscriber.blocksInfoFromHeaders()
 	return subscriber
@@ -65,35 +66,30 @@ func NewSubscriber(
 // `MaxBlocksPerRequest`; if processing more than that, multiple eth_getLogs
 // requests will be made.
 // Writes true to the done channel when finished, or false if an error occurs
-func (s *Subscriber) ProcessFromHeight(height uint64, done chan bool) {
-	defer close(done)
-
+func (s *Subscriber) ProcessFromHeight(height uint64) {
 	// Grab the latest block before filtering logs so we don't miss any before updating the db
 	latestBlockHeightCtx, latestBlockHeightCtxCancel := context.WithTimeout(context.Background(), utils.DefaultRPCTimeout)
 	defer latestBlockHeightCtxCancel()
 	latestBlockHeight, err := s.rpcClient.BlockNumber(latestBlockHeightCtx)
 	if err != nil {
-		s.logger.Error("Failed to get latest block", zap.Error(err))
-		done <- false
+		s.errChan <- fmt.Errorf("failed to get latest block: %w", err)
 		return
 	}
-	s.logger.Info(
-		"Processing historical logs",
+	log := s.logger.With(
 		zap.Uint64("fromBlockHeight", height),
-		zap.Uint64("latestBlockHeight", latestBlockHeight),
 	)
+	log.Info("Processing historical logs")
 
 	for fromBlock := height; fromBlock <= latestBlockHeight; fromBlock += MaxBlocksPerRequest {
 		toBlock := min(fromBlock+MaxBlocksPerRequest-1, latestBlockHeight)
 
 		err = s.processBlockRange(fromBlock, toBlock)
 		if err != nil {
-			s.logger.Error("Failed to process block range", zap.Error(err))
-			done <- false
+			s.errChan <- fmt.Errorf("failed to process block range: %w", err)
 			return
 		}
 	}
-	done <- true
+	log.Info("Finished processing historical logs")
 }
 
 // Process Warp messages from the block range [fromBlock, toBlock], inclusive


### PR DESCRIPTION
## Why this should be merged
Replaced `catchUpResultChan` with `errChan`. We used to use `catchUpResultChan` to dictate when to write the processed blocks to the database, but this is no longer used. We can instead use an error channel to propagate any errors from the catchup goroutine. 

We now also pass the same error channel to the subscriber, instead of giving it it's own error channel. This reduces the number of cases in the switch statement in the listener. 

## How this works

## How this was tested

## How is this documented