### PR TITLE
Fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,8 +17,8 @@ updates:
         patterns:
           - "github.com/ava-labs/*"
       weekly-ext-updates:
-        exclude-patterns::
-          - "github.com/ava-labs/*"
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Why this should be merged
Fixes dependabot. Dependabot will match dependencies to the first group that matches, so we can just use `*` for the external group. https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--

## How this works

## How this was tested

## How is this documented