### PR TITLE
Refactor keyless transaction construction

### DIFF
--- a/icm-contracts/utils/contract-deployment/contractDeploymentTools.go
+++ b/icm-contracts/utils/contract-deployment/contractDeploymentTools.go
@@ -27,8 +27,14 @@ func main() {
 		if len(os.Args) != 3 {
 			log.Fatal("Invalid argument count. Must provide JSON file containing contract bytecode.")
 		}
-		_, _, _, _, err := deploymentUtils.ConstructKeylessTransaction(
-			os.Args[2],
+
+		byteCode, err := deploymentUtils.ExtractByteCodeFromFile(os.Args[2])
+		if err != nil {
+			log.Fatal("Failed to extract byte code from file.", zap.Error(err))
+		}
+
+		_, _, _, err = deploymentUtils.ConstructKeylessTransaction(
+			byteCode,
 			true,
 			deploymentUtils.GetDefaultContractCreationGasPrice(),
 		)


### PR DESCRIPTION
## Why this should be merged
Adds helper function `AddConstructorArgsToByteCode`, which is needed to add constructor args to a contract we wish to deploy with Nick's Method.

Refactors `ConstructKeylessTransaction` to take byteCode as an input instead of the path to a bytecode file.

`ConstructKeylessTransaction` no longer returns the json deployed code which we didn't use.

## How this works

## How this was tested

## How is this documented