### PR TITLE
Add verifier and signer interfaces

### DIFF
--- a/icm-contracts/common/ITeleporterMessengerV2.sol
+++ b/icm-contracts/common/ITeleporterMessengerV2.sol
@@ -1,0 +1,53 @@
+// (c) 2026, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+// SPDX-License-Identifier: LicenseRef-Ecosystem
+
+pragma solidity 0.8.30;
+
+import {TeleporterMessageReceipt} from "@teleporter/ITeleporterMessenger.sol";
+
+struct TeleporterMessageV2 {
+    uint256 messageNonce;
+    address originSenderAddress;
+    // This is needed because we have an extra level of abstraction now. Before TeleporterMessenger was calling
+    // WarpMessenger directly, so the `senderAddress` of the warp message was the address of the TeleporterMessenger contract.
+    // Now, WarpAdapter is calling WarpMessenger, so the `originSenderAddress` of the warp message is the address of the WarpAdapter contract.
+    address originTeleporterAddress;
+    bytes32 destinationBlockchainID;
+    address destinationAddress;
+    uint256 requiredGasLimit;
+    address[] allowedRelayerAddresses;
+    TeleporterMessageReceipt[] receipts;
+    bytes message;
+}
+
+struct ICMMessage {
+    // TODO we should serialize this as bytes, and we can also have different underlying message types for different
+    // use cases other than Teleporter, but let's leave it like this for now for clarity.
+    TeleporterMessageV2 message;
+    // used to distinguish between mainnet and testnets
+    uint32 sourceNetworkID;
+    // The blockchain on which the message originated
+    bytes32 sourceBlockchainID;
+    // Arbitrary bytes that is used by receiving contracts to
+    // authenticate this message.
+    bytes attestation;
+}
+
+interface IMessageVerifier {
+    function verifyMessage(
+        ICMMessage calldata message
+    ) external returns (bool);
+}
+
+// This function signature can be changed to accept bytes to make it more generic, but I think
+// having the TeleporterMessage struct is more clear for now.
+interface IMessageSender {
+    function sendMessage(
+        TeleporterMessageV2 calldata message
+    ) external;
+}
+
+// solhint-disable-next-line no-empty-blocks
+interface IAdapter is IMessageSender, IMessageVerifier {}

--- a/icm-contracts/common/tests/ITeleporterMessengerV2.t.sol
+++ b/icm-contracts/common/tests/ITeleporterMessengerV2.t.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test} from "@forge-std/Test.sol";
+import {TeleporterMessageV2, ICMMessage} from "../ITeleporterMessengerV2.sol";
+import {TeleporterMessageReceipt} from "@teleporter/ITeleporterMessenger.sol";
+
+contract ICMTest is Test {
+    /*
+     * @dev Test to make sure a round trip of serialization is a no-op
+     */
+    function testRoundTripRawMessage(
+        bytes4 sourceNetworkID,
+        bytes32 sourceBlockchainID,
+        bytes memory payload
+    ) public pure {
+        TeleporterMessageV2 memory teleporterMessage = TeleporterMessageV2({
+            messageNonce: 0,
+            originSenderAddress: address(123),
+            originTeleporterAddress: address(456),
+            destinationBlockchainID: bytes32(hex"abcd"),
+            destinationAddress: address(987),
+            requiredGasLimit: 100000,
+            allowedRelayerAddresses: new address[](0),
+            receipts: new TeleporterMessageReceipt[](0),
+            message: payload
+        });
+
+        ICMMessage memory icmMessage = ICMMessage({
+            message: teleporterMessage,
+            sourceNetworkID: uint32(sourceNetworkID),
+            sourceBlockchainID: sourceBlockchainID,
+            attestation: abi.encode(1)
+        });
+
+        bytes memory serialized = abi.encode(icmMessage);
+        ICMMessage memory deserializedICM = abi.decode(serialized, (ICMMessage));
+        assertEq(icmMessage.sourceNetworkID, deserializedICM.sourceNetworkID);
+        assertEq(icmMessage.sourceBlockchainID, deserializedICM.sourceBlockchainID);
+        assertEq(icmMessage.attestation, deserializedICM.attestation);
+
+        TeleporterMessageV2 memory deserializedTeleporterMessage = deserializedICM.message;
+        assertEq(teleporterMessage.messageNonce, deserializedTeleporterMessage.messageNonce);
+        assertEq(
+            teleporterMessage.originSenderAddress, deserializedTeleporterMessage.originSenderAddress
+        );
+        assertEq(
+            teleporterMessage.originTeleporterAddress,
+            deserializedTeleporterMessage.originTeleporterAddress
+        );
+        assertEq(
+            teleporterMessage.destinationBlockchainID,
+            deserializedTeleporterMessage.destinationBlockchainID
+        );
+        assertEq(
+            teleporterMessage.destinationAddress, deserializedTeleporterMessage.destinationAddress
+        );
+        assertEq(teleporterMessage.requiredGasLimit, deserializedTeleporterMessage.requiredGasLimit);
+        assertEq(
+            teleporterMessage.allowedRelayerAddresses.length,
+            deserializedTeleporterMessage.allowedRelayerAddresses.length
+        );
+        assertEq(teleporterMessage.receipts.length, deserializedTeleporterMessage.receipts.length);
+        assertEq(
+            keccak256(teleporterMessage.message), keccak256(deserializedTeleporterMessage.message)
+        );
+    }
+}


### PR DESCRIPTION
## Why this should be merged
This adds the `IMessageVerifier`, `IMessageSender`, and `IAdapter` interfaces. 

It also changes the `ICMMessage` struct to fit better with these interfaces. We may need another underlying message type at the same level as `TeleporterMessageV2` for use with non-teleporter ICM Messages, such as those sent from the p-chain.

## How this works

## How this was tested

## How is this documented