### PR TITLE
Reworked the contracts to fit with the existing abstractions

### DIFF
--- a/icm-contracts/ethereum/AvalancheValidatorSetRegistry.sol
+++ b/icm-contracts/ethereum/AvalancheValidatorSetRegistry.sol
@@ -113,12 +113,9 @@ contract AvalancheValidatorSetRegistry is IAvalancheValidatorSetRegistry {
             partialSet.shardsReceived = 1;
             partialSet.partialWeight = validatorWeight;
             partialSet.inProgress = true;
-            for (uint256 i = 0; i < numValidators;) {
-                partialSet.validators.push(validators[i]);
-                unchecked {
-                    ++i;
-                }
-            }
+            applyPartialUpdate(
+                validatorSetMetadata.avalancheBlockchainID, validators, validatorWeight
+            );
 
             if (!isRegistered(message.sourceBlockchainID)) {
                 ValidatorSet storage valSet =
@@ -172,17 +169,6 @@ contract AvalancheValidatorSetRegistry is IAvalancheValidatorSetRegistry {
     }
 
     /**
-     * @notice Updates an existing validator set by applying a diff.
-     */
-    /* solhint-disable-next-line no-unused-vars */
-    function updateValidatorSetWithDiff(
-        /* solhint-disable-next-line no-unused-vars */
-        ICMMessage calldata message
-    ) external virtual {
-        revert("Not implemented");
-    }
-
-    /**
      * @notice Gets the validator set for a given Avalanche blockchain ID.
      */
     function getValidatorSet(
@@ -199,6 +185,23 @@ contract AvalancheValidatorSetRegistry is IAvalancheValidatorSetRegistry {
      */
     /* solhint-disable-next-line no-unused-vars */
     function applyShard(ValidatorSetShard calldata shard, bytes memory shardBytes) public virtual {
+        revert("Not implemented");
+    }
+
+    /**
+     * @notice The logic for how the update from a shard should be applied to a partially updated set.
+     * @param avalancheBlockchainID the Avalanche blockchain ID of the validator set we are updating
+     * @param partialUpdate the actual partially updated set
+     * @param partialWeightUpdate an update to the weight of the partial set
+     */
+    function applyPartialUpdate(
+        /* solhint-disable-next-line no-unused-vars */
+        bytes32 avalancheBlockchainID,
+        /* solhint-disable-next-line no-unused-vars */
+        Validator[] memory partialUpdate,
+        /* solhint-disable-next-line no-unused-vars */
+        uint64 partialWeightUpdate
+    ) public virtual {
         revert("Not implemented");
     }
 
@@ -299,75 +302,6 @@ contract SubsetUpdater is AvalancheValidatorSetRegistry {
     ) payable AvalancheValidatorSetRegistry(avalancheNetworkID_, initialValidatorSetData) {}
 
     /**
-     * @notice Updates an existing validator set by applying a diff.
-     * @dev This function assumes the number of changes in the `diff`
-     * (validators added + removed + modified) is small relative to the total validator set size.
-     * @param message The ICM message containing the ValidatorSetDiff.
-     */
-    function updateValidatorSetWithDiff(
-        ICMMessage calldata message
-    ) external override {
-        // Safety checks
-        require(message.sourceNetworkID == avalancheNetworkID, "Network ID mismatch");
-        bytes32 chainID = message.sourceBlockchainID;
-        require(isRegistered(chainID), "Validator set not registered");
-        require(
-            !isRegistrationInProgress(chainID),
-            "Cannot apply diff with another registration in progress"
-        );
-        verifyICMMessage(message, chainID);
-
-        // Apply the diff
-        ValidatorSet memory currentValidatorSet = this.getValidatorSet(chainID);
-        ValidatorSetDiff memory diff = ValidatorSets.parseValidatorSetDiff(
-            message.rawMessage, currentValidatorSet.validators.length
-        );
-        require(diff.currentHeight > currentValidatorSet.pChainHeight, "Invalid blockchain height");
-
-        (Validator[] memory newValidators, uint64 newWeight) =
-            ValidatorSets.applyValidatorSetDiff(currentValidatorSet.validators, diff);
-
-        // Update state
-        // NOTE: We can simplify this code using --via-ir once a stable compiler version is out.
-        ValidatorSet storage storageSet = _validatorSets[chainID];
-        storageSet.pChainHeight = diff.currentHeight;
-        storageSet.pChainTimestamp = diff.currentTimestamp;
-        storageSet.totalWeight = newWeight;
-        {
-            uint256 oldValLen = storageSet.validators.length;
-            uint256 newValLen = newValidators.length;
-            uint256 minValLen = newValLen < oldValLen ? newValLen : oldValLen;
-            // Overwrite
-            uint256 i = 0;
-            for (; i < minValLen;) {
-                storageSet.validators[i] = newValidators[i];
-                unchecked {
-                    ++i;
-                }
-            }
-            // Push
-            if (newValLen > oldValLen) {
-                for (; i < newValLen;) {
-                    storageSet.validators.push(newValidators[i]);
-                    unchecked {
-                        ++i;
-                    }
-                }
-                // Pop
-            } else if (oldValLen > newValLen) {
-                uint256 diffLen = oldValLen - newValLen;
-                for (uint256 j = 0; j < diffLen;) {
-                    storageSet.validators.pop();
-                    unchecked {
-                        ++j;
-                    }
-                }
-            }
-        }
-        emit ValidatorSetUpdated(chainID);
-    }
-
-    /**
      * @dev Applies a set of validators to partial to a set that has been registered.
      */
     function applyShard(
@@ -382,13 +316,7 @@ contract SubsetUpdater is AvalancheValidatorSetRegistry {
         require(validatorWeight > 0, "Total weight must exceed 0");
 
         // update the partial validator set
-        for (uint256 i = 0; i < validators.length;) {
-            _partialValidatorSets[avalancheBlockchainID].validators.push(validators[i]);
-            unchecked {
-                ++i;
-            }
-        }
-        _partialValidatorSets[avalancheBlockchainID].partialWeight += validatorWeight;
+        applyPartialUpdate(avalancheBlockchainID, validators, validatorWeight);
         _partialValidatorSets[avalancheBlockchainID].shardsReceived += 1;
 
         // We have received all shards. Place this validator set into the mapping
@@ -400,6 +328,24 @@ contract SubsetUpdater is AvalancheValidatorSetRegistry {
             _validatorSets[avalancheBlockchainID].totalWeight =
                 _partialValidatorSets[avalancheBlockchainID].partialWeight;
         }
+    }
+
+    /**
+     * @dev Simply push the validators onto the end of the existing partial update and add the
+     * new weight to the total
+     */
+    function applyPartialUpdate(
+        bytes32 avalancheBlockchainID,
+        Validator[] memory partialUpdate,
+        uint64 partialWeightUpdate
+    ) public override {
+        for (uint256 i = 0; i < partialUpdate.length;) {
+            _partialValidatorSets[avalancheBlockchainID].validators.push(partialUpdate[i]);
+            unchecked {
+                ++i;
+            }
+        }
+        _partialValidatorSets[avalancheBlockchainID].partialWeight += partialWeightUpdate;
     }
 
     /**
@@ -432,5 +378,82 @@ contract SubsetUpdater is AvalancheValidatorSetRegistry {
         require(validators.length > 0, "Validator set cannot be empty");
         require(totalWeight > 0, "Total weight must exceed 0");
         return (validatorSetMetadata, validators, totalWeight);
+    }
+}
+
+contract DiffUpdater is AvalancheValidatorSetRegistry {
+    constructor(
+        uint32 avalancheNetworkID_,
+        // The metadata about the initial validator set. This is used
+        // allow the actual validator set to be populated across multiple
+        // transactions
+        ValidatorSetMetadata memory initialValidatorSetData
+    ) payable AvalancheValidatorSetRegistry(avalancheNetworkID_, initialValidatorSetData) {}
+
+    /**
+     * @notice Updates an existing validator set by applying a diff.
+     * @dev This function assumes the number of changes in the `diff`
+     * (validators added + removed + modified) is small relative to the total validator set size.
+     */
+    function applyShard(
+        ValidatorSetShard calldata shard,
+        bytes memory shardBytes
+    ) public override {
+        bytes32 chainID = shard.avalancheBlockchainID;
+        // Apply the diff
+        PartialValidatorSet memory currentValidatorSet = _partialValidatorSets[chainID];
+        ValidatorSetDiff memory diff =
+            ValidatorSets.parseValidatorSetDiff(shardBytes, currentValidatorSet.validators.length);
+        // Safety checks
+        require(diff.currentHeight > currentValidatorSet.pChainHeight, "Invalid blockchain height");
+
+        (Validator[] memory newValidators, uint64 newWeight) =
+            ValidatorSets.applyValidatorSetDiff(currentValidatorSet.validators, diff);
+
+        currentValidatorSet.pChainHeight = diff.currentHeight;
+        currentValidatorSet.pChainTimestamp = diff.currentTimestamp;
+        applyPartialUpdate(chainID, newValidators, newWeight);
+        emit ValidatorSetUpdated(chainID);
+    }
+
+    /**
+     * @dev Note that the operations of changes from a diff are commutative. So we can successively
+     * apply a subset of them and always keep the latest result as the partial update.
+     */
+    function applyPartialUpdate(
+        bytes32 avalancheBlockchainID,
+        Validator[] memory partialUpdate,
+        uint64 partialWeightUpdate
+    ) public override {
+        _partialValidatorSets[avalancheBlockchainID].validators = partialUpdate;
+        _partialValidatorSets[avalancheBlockchainID].partialWeight = partialWeightUpdate;
+    }
+
+    /**
+     * @dev The returned validator set if the result of applying the first diff to the currently registered
+     * set. The weight returned is the weight of the resulting set
+     */
+    function parseValidatorSetMetadata(
+        ICMMessage calldata icmMessage,
+        bytes calldata shardBytes
+    ) public view override returns (ValidatorSetMetadata memory, Validator[] memory, uint64) {
+        // Parse the validator set state payload.
+        ValidatorSetMetadata memory validatorSetMetadata =
+            ValidatorSets.parseValidatorSetMetadata(icmMessage.rawMessage);
+        // Check that the first validator set shard hash matches the hash of the serialized validator set.
+        require(
+            validatorSetMetadata.shardHashes[0] == sha256(shardBytes), "Validator set hash mismatch"
+        );
+
+        bytes32 chainID = icmMessage.sourceBlockchainID;
+        // Apply the diff
+        ValidatorSet memory currentValidatorSet = this.getValidatorSet(chainID);
+        ValidatorSetDiff memory diff =
+            ValidatorSets.parseValidatorSetDiff(shardBytes, currentValidatorSet.validators.length);
+        require(diff.currentHeight > currentValidatorSet.pChainHeight, "Invalid blockchain height");
+
+        (Validator[] memory newValidators, uint64 newWeight) =
+            ValidatorSets.applyValidatorSetDiff(currentValidatorSet.validators, diff);
+        return (validatorSetMetadata, newValidators, newWeight);
     }
 }


### PR DESCRIPTION
## Why this should be merged
This PR reworks the diff updater into a separate contract implementing the expected interface for the validator set registry. It does not fix the tests or the redundancies in some of the struct definitions. This also handles sharding diffs.
## How this works

## How this was tested

## How is this documented