### PR TITLE
Add protocol address to relayer ID

### DIFF
--- a/database/database_test.go
+++ b/database/database_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var testingProtocolAddress = common.HexToAddress("0xd81545385803bCD83bd59f58Ba2d2c0562387F83")
+
 func TestIsKeyNotFoundError(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -57,7 +59,7 @@ func TestCalculateRelayerID(t *testing.T) {
 			destinationBlockchainID: id2,
 			originSenderAddress:     AllAllowedAddress,
 			destinationAddress:      AllAllowedAddress,
-			expected:                common.HexToHash("0xf8a8467088fd6f8ad4577408ddda1607e2702ca9827d7fd556c46adae624b7a2"),
+			expected:                common.HexToHash("0xbeea4a95895a40befa2295a8cd56586cce9ea6d28d8616569c542cc1a632edb3"),
 		},
 		{
 			name:                    "zero source address",
@@ -65,7 +67,7 @@ func TestCalculateRelayerID(t *testing.T) {
 			destinationBlockchainID: id2,
 			originSenderAddress:     AllAllowedAddress,
 			destinationAddress:      common.HexToAddress("0x0123456789abcdef0123456789abcdef01234567"),
-			expected:                common.HexToHash("0xa20ede2231d43d072800ad436a4ca8844f9ddd9cb4174f4cc3046e0958e48320"),
+			expected:                common.HexToHash("0x256b953633895cebec219cca02360c095afc40879958ff76cf7b71ece6f64f10"),
 		},
 		{
 			name:                    "zero destination address",
@@ -73,7 +75,7 @@ func TestCalculateRelayerID(t *testing.T) {
 			destinationBlockchainID: id2,
 			originSenderAddress:     common.HexToAddress("0x0123456789abcdef0123456789abcdef01234567"),
 			destinationAddress:      AllAllowedAddress,
-			expected:                common.HexToHash("0xb205a049831478f55b768a4c875b2085339b6053831ecde8a3d406f9d13454a5"),
+			expected:                common.HexToHash("0x90acac45798533ca7263420a73f924b22860184920cd6650aab99a19695f9abb"),
 		},
 		{
 			name:                    "all non-zero",
@@ -81,11 +83,12 @@ func TestCalculateRelayerID(t *testing.T) {
 			destinationBlockchainID: id2,
 			originSenderAddress:     common.HexToAddress("0x0123456789abcdef0123456789abcdef01234567"),
 			destinationAddress:      common.HexToAddress("0x0123456789abcdef0123456789abcdef01234567"),
-			expected:                common.HexToHash("0x6661512bc3b5689b28a4c2519425f725b5681b90fea937433103c846f742f918"),
+			expected:                common.HexToHash("0xefe8c09dd4232671543a04507abba2a6a3d60ed0b65a2296dc3707202738a7b4"),
 		},
 	}
 	for _, testCase := range testCases {
 		result := CalculateRelayerID(
+			testingProtocolAddress,
 			testCase.sourceBlockchainID,
 			testCase.destinationBlockchainID,
 			testCase.originSenderAddress,
@@ -174,36 +177,42 @@ func TestGetConfigRelayerKeys(t *testing.T) {
 
 	targetIDs := []RelayerID{
 		NewRelayerID(
+			testingProtocolAddress,
 			srcCfg1.GetBlockchainID(),
 			dstCfg1.GetBlockchainID(),
 			AllAllowedAddress,
 			AllAllowedAddress,
 		),
 		NewRelayerID(
+			testingProtocolAddress,
 			srcCfg2.GetBlockchainID(),
 			dstCfg1.GetBlockchainID(),
 			allowedAddress,
 			AllAllowedAddress,
 		),
 		NewRelayerID(
+			testingProtocolAddress,
 			srcCfg3.GetBlockchainID(),
 			dstCfg1.GetBlockchainID(),
 			AllAllowedAddress,
 			AllAllowedAddress,
 		),
 		NewRelayerID(
+			testingProtocolAddress,
 			srcCfg4.GetBlockchainID(),
 			dstCfg1.GetBlockchainID(),
 			allowedAddress,
 			AllAllowedAddress,
 		),
 		NewRelayerID(
+			testingProtocolAddress,
 			srcCfg5.GetBlockchainID(),
 			dstCfg1.GetBlockchainID(),
 			AllAllowedAddress,
 			allowedAddress,
 		),
 		NewRelayerID(
+			testingProtocolAddress,
 			srcCfg6.GetBlockchainID(),
 			dstCfg1.GetBlockchainID(),
 			allowedAddress,

--- a/database/json_file_storage_test.go
+++ b/database/json_file_storage_test.go
@@ -25,6 +25,7 @@ func createRelayerIDs(blockchainIDs []ids.ID) []RelayerID {
 		for allowedDestination := range destinationsBlockchainIDs {
 			id, _ := ids.FromString(allowedDestination)
 			relayerIDs = append(relayerIDs, NewRelayerID(
+				testingProtocolAddress,
 				blockchainID,
 				id,
 				AllAllowedAddress,

--- a/database/relayer_id.go
+++ b/database/relayer_id.go
@@ -20,6 +20,7 @@ var (
 
 // RelayerID is a unique identifier for an application relayer
 type RelayerID struct {
+	ProtocolAddress         common.Address
 	SourceBlockchainID      ids.ID
 	DestinationBlockchainID ids.ID
 	OriginSenderAddress     common.Address
@@ -28,18 +29,21 @@ type RelayerID struct {
 }
 
 func NewRelayerID(
+	protocolAddress common.Address,
 	sourceBlockchainID ids.ID,
 	destinationBlockchainID ids.ID,
 	originSenderAddress common.Address,
 	destinationAddress common.Address,
 ) RelayerID {
 	id := CalculateRelayerID(
+		protocolAddress,
 		sourceBlockchainID,
 		destinationBlockchainID,
 		originSenderAddress,
 		destinationAddress,
 	)
 	return RelayerID{
+		ProtocolAddress:         protocolAddress,
 		SourceBlockchainID:      sourceBlockchainID,
 		DestinationBlockchainID: destinationBlockchainID,
 		OriginSenderAddress:     originSenderAddress,
@@ -50,6 +54,27 @@ func NewRelayerID(
 
 // Standalone utility to calculate a relayer ID.
 func CalculateRelayerID(
+	protocolAddress common.Address,
+	sourceBlockchainID ids.ID,
+	destinationBlockchainID ids.ID,
+	originSenderAddress common.Address,
+	destinationAddress common.Address,
+) common.Hash {
+	return crypto.Keccak256Hash(
+		[]byte(strings.Join(
+			[]string{
+				protocolAddress.String(),
+				sourceBlockchainID.String(),
+				destinationBlockchainID.String(),
+				originSenderAddress.String(),
+				destinationAddress.String(),
+			},
+			"-",
+		)),
+	)
+}
+
+func CalculateRelayerIDHistorical(
 	sourceBlockchainID ids.ID,
 	destinationBlockchainID ids.ID,
 	originSenderAddress common.Address,
@@ -85,20 +110,23 @@ func GetSourceBlockchainRelayerIDs(sourceBlockchain *config.SourceBlockchain) []
 	if len(srcAddresses) == 0 {
 		srcAddresses = append(srcAddresses, AllAllowedAddress)
 	}
-	for _, srcAddress := range srcAddresses {
-		for _, dst := range sourceBlockchain.SupportedDestinations {
-			dstAddresses := dst.GetAddresses()
-			// If no addresses are provided, use the zero address to construct the relayer ID
-			if len(dstAddresses) == 0 {
-				dstAddresses = append(dstAddresses, AllAllowedAddress)
-			}
-			for _, dstAddress := range dstAddresses {
-				ids = append(ids, NewRelayerID(
-					sourceBlockchain.GetBlockchainID(),
-					dst.GetBlockchainID(),
-					srcAddress,
-					dstAddress,
-				))
+	for _, protocolAddress := range sourceBlockchain.ProtocolAddresses() {
+		for _, srcAddress := range srcAddresses {
+			for _, dst := range sourceBlockchain.SupportedDestinations {
+				dstAddresses := dst.GetAddresses()
+				// If no addresses are provided, use the zero address to construct the relayer ID
+				if len(dstAddresses) == 0 {
+					dstAddresses = append(dstAddresses, AllAllowedAddress)
+				}
+				for _, dstAddress := range dstAddresses {
+					ids = append(ids, NewRelayerID(
+						protocolAddress,
+						sourceBlockchain.GetBlockchainID(),
+						dst.GetBlockchainID(),
+						srcAddress,
+						dstAddress,
+					))
+				}
 			}
 		}
 	}

--- a/database/utils.go
+++ b/database/utils.go
@@ -71,7 +71,19 @@ func CalculateStartingBlockHeight(
 // Helper function to get the latest processed block height from the database.
 func GetLatestProcessedBlockHeight(db RelayerDatabase, relayerID RelayerID) (uint64, error) {
 	latestProcessedBlockData, err := db.Get(relayerID.ID, LatestProcessedBlockKey)
-	if err != nil {
+	// If we don't find the key, fallback to see if there is an entry for the historical relayer ID
+	// (for backwards compatibility with old config formats)
+	if IsKeyNotFoundError(err) {
+		latestProcessedBlockData, err = db.Get(CalculateRelayerIDHistorical(
+			relayerID.SourceBlockchainID,
+			relayerID.DestinationBlockchainID,
+			relayerID.OriginSenderAddress,
+			relayerID.DestinationAddress,
+		), LatestProcessedBlockKey)
+		if err != nil {
+			return 0, err
+		}
+	} else if err != nil {
 		return 0, err
 	}
 	latestProcessedBlock, err := strconv.ParseUint(string(latestProcessedBlockData), 10, 64)

--- a/database/utils.go
+++ b/database/utils.go
@@ -72,7 +72,7 @@ func CalculateStartingBlockHeight(
 func GetLatestProcessedBlockHeight(db RelayerDatabase, relayerID RelayerID) (uint64, error) {
 	latestProcessedBlockData, err := db.Get(relayerID.ID, LatestProcessedBlockKey)
 	if err != nil {
-		// Check if we have the historical key for the relayerID, which is used by older versions of the relayer. 
+		// Check if we have the historical key for the relayerID, which is used by older versions of the relayer.
 		// If we do, we should use that value instead of returning an error.
 		historicalRelayerID := CalculateRelayerIDHistorical(
 			relayerID.SourceBlockchainID,

--- a/database/utils.go
+++ b/database/utils.go
@@ -72,7 +72,20 @@ func CalculateStartingBlockHeight(
 func GetLatestProcessedBlockHeight(db RelayerDatabase, relayerID RelayerID) (uint64, error) {
 	latestProcessedBlockData, err := db.Get(relayerID.ID, LatestProcessedBlockKey)
 	if err != nil {
-		return 0, err
+		// Check if we have the historical key for the relayerID, which is used by older versions of the relayer. 
+		// If we do, we should use that value instead of returning an error.
+		historicalRelayerID := CalculateRelayerIDHistorical(
+			relayerID.SourceBlockchainID,
+			relayerID.DestinationBlockchainID,
+			relayerID.OriginSenderAddress,
+			relayerID.DestinationAddress,
+		)
+		var historicalErr error
+		latestProcessedBlockData, historicalErr = db.Get(historicalRelayerID, LatestProcessedBlockKey)
+		if historicalErr != nil {
+			// return the original error
+			return 0, err
+		}
 	}
 
 	latestProcessedBlock, err := strconv.ParseUint(string(latestProcessedBlockData), 10, 64)

--- a/database/utils.go
+++ b/database/utils.go
@@ -71,21 +71,10 @@ func CalculateStartingBlockHeight(
 // Helper function to get the latest processed block height from the database.
 func GetLatestProcessedBlockHeight(db RelayerDatabase, relayerID RelayerID) (uint64, error) {
 	latestProcessedBlockData, err := db.Get(relayerID.ID, LatestProcessedBlockKey)
-	// If we don't find the key, fallback to see if there is an entry for the historical relayer ID
-	// (for backwards compatibility with old config formats)
-	if IsKeyNotFoundError(err) {
-		latestProcessedBlockData, err = db.Get(CalculateRelayerIDHistorical(
-			relayerID.SourceBlockchainID,
-			relayerID.DestinationBlockchainID,
-			relayerID.OriginSenderAddress,
-			relayerID.DestinationAddress,
-		), LatestProcessedBlockKey)
-		if err != nil {
-			return 0, err
-		}
-	} else if err != nil {
+	if err != nil {
 		return 0, err
 	}
+
 	latestProcessedBlock, err := strconv.ParseUint(string(latestProcessedBlockData), 10, 64)
 	if err != nil {
 		return 0, err

--- a/icm-contracts/tests/flows/services/allowed_addresses.go
+++ b/icm-contracts/tests/flows/services/allowed_addresses.go
@@ -44,6 +44,7 @@ func AllowedAddresses(
 ) {
 	l1AInfo := network.GetPrimaryNetworkInfo()
 	l1BInfo, _ := network.GetTwoL1s()
+	teleporterAddress := teleporter.TeleporterMessengerAddress(l1AInfo.BlockchainID)
 	fundedAddress, fundedKey := network.GetFundedAccountInfo()
 	err := utils.ClearRelayerStorage()
 	Expect(err).Should(BeNil())
@@ -364,24 +365,28 @@ func AllowedAddresses(
 
 	// Create relayer keys that allow all source and destination addresses
 	relayerID1 := database.NewRelayerID(
+		teleporterAddress,
 		l1AInfo.BlockchainID,
 		l1BInfo.BlockchainID,
 		database.AllAllowedAddress,
 		database.AllAllowedAddress,
 	)
 	relayerID2 := database.NewRelayerID(
+		teleporterAddress,
 		l1AInfo.BlockchainID,
 		l1BInfo.BlockchainID,
 		allowedAddresses[relayer2AllowedSrcAddressIdx],
 		database.AllAllowedAddress,
 	)
 	relayerID3 := database.NewRelayerID(
+		teleporterAddress,
 		l1AInfo.BlockchainID,
 		l1BInfo.BlockchainID,
 		database.AllAllowedAddress,
 		allowedAddresses[relayer3AllowedDstAddressIdx],
 	)
 	relayerID4 := database.NewRelayerID(
+		teleporterAddress,
 		l1AInfo.BlockchainID,
 		l1BInfo.BlockchainID,
 		allowedAddresses[relayer4AllowedSrcAddressIdx],

--- a/icm-contracts/tests/flows/services/basic_relay.go
+++ b/icm-contracts/tests/flows/services/basic_relay.go
@@ -30,6 +30,7 @@ func BasicRelay(
 ) {
 	l1AInfo := network.GetPrimaryNetworkInfo()
 	l1BInfo, _ := network.GetTwoL1s()
+	teleporterAddress := teleporter.TeleporterMessengerAddress(l1AInfo.BlockchainID)
 	fundedAddress, fundedKey := network.GetFundedAccountInfo()
 	err := utils.ClearRelayerStorage()
 	Expect(err).Should(BeNil())
@@ -123,13 +124,17 @@ func BasicRelay(
 	Expect(err).Should(BeNil())
 
 	// Create relayer keys that allow all source and destination addresses
+
+	// The address will be the same for all chains
 	relayerIDA := database.CalculateRelayerID(
+		teleporterAddress,
 		l1AInfo.BlockchainID,
 		l1BInfo.BlockchainID,
 		database.AllAllowedAddress,
 		database.AllAllowedAddress,
 	)
 	relayerIDB := database.CalculateRelayerID(
+		teleporterAddress,
 		l1BInfo.BlockchainID,
 		l1AInfo.BlockchainID,
 		database.AllAllowedAddress,

--- a/icm-contracts/tests/flows/teleporter/add_fee_amount.go
+++ b/icm-contracts/tests/flows/teleporter/add_fee_amount.go
@@ -19,7 +19,7 @@ func AddFeeAmount(
 ) {
 	l1AInfo := network.GetPrimaryNetworkInfo()
 	l1BInfo, _ := network.GetTwoL1s()
-	teleporterContractAddress := teleporter.TeleporterMessengerAddress(l1AInfo.BlockchainID)
+	teleporterAddress := teleporter.TeleporterMessengerAddress(l1AInfo.BlockchainID)
 	fundedAddress, fundedKey := network.GetFundedAccountInfo()
 
 	// Use mock token as the fee token
@@ -31,7 +31,7 @@ func AddFeeAmount(
 	utils.ERC20Approve(
 		ctx,
 		mockToken,
-		teleporterContractAddress,
+		teleporterAddress,
 		big.NewInt(1e18),
 		l1AInfo,
 		fundedKey,

--- a/icm-contracts/tests/flows/teleporter/basic_send_receive.go
+++ b/icm-contracts/tests/flows/teleporter/basic_send_receive.go
@@ -20,7 +20,7 @@ func BasicSendReceive(
 ) {
 	l1AInfo := network.GetPrimaryNetworkInfo()
 	l1BInfo, _ := network.GetTwoL1s()
-	teleporterContractAddress := teleporter.TeleporterMessengerAddress(l1AInfo.BlockchainID)
+	teleporterAddress := teleporter.TeleporterMessengerAddress(l1AInfo.BlockchainID)
 	fundedAddress, fundedKey := network.GetFundedAccountInfo()
 
 	// Send a transaction to L1 A to issue an ICM Message from the Teleporter contract to L1 B
@@ -41,7 +41,7 @@ func BasicSendReceive(
 	utils.ERC20Approve(
 		ctx,
 		feeToken,
-		teleporterContractAddress,
+		teleporterAddress,
 		big.NewInt(0).Mul(big.NewInt(1e18),
 			big.NewInt(10)),
 		l1AInfo,

--- a/icm-contracts/tests/flows/teleporter/registry/pause_teleporter.go
+++ b/icm-contracts/tests/flows/teleporter/registry/pause_teleporter.go
@@ -17,11 +17,11 @@ func PauseTeleporter(
 	l1AInfo := network.GetPrimaryNetworkInfo()
 	l1BInfo, _ := network.GetTwoL1s()
 	fundedAddress, fundedKey := network.GetFundedAccountInfo()
+	teleporterAddress := teleporter.TeleporterMessengerAddress(l1AInfo.BlockchainID)
 
 	//
 	// Deploy TestMessenger to L1s A and B
 	//
-	teleporterAddress := teleporter.TeleporterMessengerAddress(l1AInfo.BlockchainID)
 	_, testMessengerA := utils.DeployTestMessenger(
 		ctx,
 		fundedKey,

--- a/icm-contracts/tests/flows/teleporter/send_specific_receipts.go
+++ b/icm-contracts/tests/flows/teleporter/send_specific_receipts.go
@@ -27,7 +27,7 @@ func SendSpecificReceipts(
 	l1BInfo, _ := network.GetTwoL1s()
 	l1ATeleporterMessenger := teleporter.TeleporterMessenger(&l1AInfo)
 	l1BTeleporterMessenger := teleporter.TeleporterMessenger(&l1BInfo)
-	teleporterContractAddress := teleporter.TeleporterMessengerAddress(l1AInfo.BlockchainID)
+	teleporterAddress := teleporter.TeleporterMessengerAddress(l1AInfo.BlockchainID)
 	_, fundedKey := network.GetFundedAccountInfo()
 
 	aggregator := network.GetSignatureAggregator()
@@ -43,7 +43,7 @@ func SendSpecificReceipts(
 	utils.ERC20Approve(
 		ctx,
 		mockToken,
-		teleporterContractAddress,
+		teleporterAddress,
 		big.NewInt(0).Mul(big.NewInt(1e18),
 			big.NewInt(10)),
 		l1AInfo,
@@ -227,13 +227,13 @@ func SendSpecificReceipts(
 		zap.Any("receipts", receiveEvent.Message.Receipts),
 	)
 	Expect(receiptIncluded(
-		teleporterContractAddress,
+		teleporterAddress,
 		messageID1,
 		l1AInfo,
 		l1BInfo,
 		receiveEvent.Message.Receipts)).Should(BeTrue())
 	Expect(receiptIncluded(
-		teleporterContractAddress,
+		teleporterAddress,
 		messageID2,
 		l1AInfo,
 		l1BInfo,

--- a/relayer/application_relayer.go
+++ b/relayer/application_relayer.go
@@ -116,7 +116,7 @@ func NewApplicationRelayer(
 		}
 	}
 
-	ar := ApplicationRelayer{
+	return &ApplicationRelayer{
 		logger:                    logger,
 		metrics:                   metrics,
 		network:                   network,
@@ -128,9 +128,7 @@ func NewApplicationRelayer(
 		sourceWarpSignatureClient: warpClient,
 		signatureAggregator:       signatureAggregator,
 		processMessageSemaphore:   processMessageSemaphore,
-	}
-
-	return &ar, nil
+	}, nil
 }
 
 // Process [msgs] at height [height] by relaying each message to the destination chain.

--- a/relayer/application_relayer.go
+++ b/relayer/application_relayer.go
@@ -70,7 +70,7 @@ func NewApplicationRelayer(
 	network *peers.AppRequestNetwork,
 	relayerID database.RelayerID,
 	destinationClient vms.DestinationClient,
-	sourceBlockchain config.SourceBlockchain,
+	sourceBlockchain *config.SourceBlockchain,
 	checkpointManager CheckpointManager,
 	cfg *config.Config,
 	signatureAggregator *aggregator.SignatureAggregator,

--- a/relayer/checkpoint/checkpoint.go
+++ b/relayer/checkpoint/checkpoint.go
@@ -57,7 +57,10 @@ func NewCheckpointManager(
 
 	committedHeight := max(storedHeight, startingHeight)
 
-	cm := &CheckpointManager{
+	metrics.UpdateCommittedHeight(relayerID, committedHeight)
+	metrics.UpdatePendingCommitsHeapLength(relayerID, 0)
+
+	return &CheckpointManager{
 		logger:          logger,
 		metrics:         metrics,
 		database:        db,
@@ -67,12 +70,7 @@ func NewCheckpointManager(
 		lock:            &sync.RWMutex{},
 		pendingCommits:  h,
 		dirty:           true,
-	}
-
-	metrics.UpdateCommittedHeight(relayerID, committedHeight)
-	metrics.UpdatePendingCommitsHeapLength(relayerID, 0)
-
-	return cm, nil
+	}, nil
 }
 
 func (cm *CheckpointManager) Run() {

--- a/relayer/config/source_blockchain.go
+++ b/relayer/config/source_blockchain.go
@@ -28,6 +28,7 @@ type SourceBlockchain struct {
 	WarpAPIEndpoint basecfg.APIConfig `mapstructure:"warp-api-endpoint" json:"warp-api-endpoint"` //nolint:lll
 
 	// convenience fields to access parsed data after initialization
+	protocolAddresses            []common.Address
 	subnetID                     ids.ID
 	blockchainID                 ids.ID
 	allowedOriginSenderAddresses []common.Address
@@ -58,6 +59,7 @@ func (s *SourceBlockchain) Validate(destinationBlockchainIDs *set.Set[string]) e
 		if !common.IsHexAddress(messageContractAddress) {
 			return fmt.Errorf("invalid message contract address in EVM source subnet: %s", messageContractAddress)
 		}
+		s.protocolAddresses = append(s.protocolAddresses, common.HexToAddress(messageContractAddress))
 	}
 
 	// Validate message settings correspond to a supported message protocol
@@ -156,6 +158,10 @@ func (s *SourceBlockchain) GetAllowedOriginSenderAddresses() []common.Address {
 
 func (s *SourceBlockchain) UseAppRequestNetwork() bool {
 	return s.useAppRequestNetwork
+}
+
+func (s *SourceBlockchain) ProtocolAddresses() []common.Address {
+	return s.protocolAddresses
 }
 
 // Specifies a supported destination blockchain and addresses for a source blockchain.

--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -535,7 +535,7 @@ func createApplicationRelayers(
 			checkpointMetrics,
 			db,
 			ticker,
-			*sourceBlockchain,
+			sourceBlockchain,
 			network,
 			cfg,
 			currentHeight,
@@ -565,7 +565,7 @@ func createApplicationRelayersForSourceChain(
 	checkpointMetrics *checkpoint.CheckpointManagerMetrics,
 	db database.RelayerDatabase,
 	ticker *utils.Ticker,
-	sourceBlockchain config.SourceBlockchain,
+	sourceBlockchain *config.SourceBlockchain,
 	network *peers.AppRequestNetwork,
 	cfg *config.Config,
 	currentHeight uint64,
@@ -587,7 +587,7 @@ func createApplicationRelayersForSourceChain(
 		minHeight = height
 	}
 
-	for _, relayerID := range database.GetSourceBlockchainRelayerIDs(&sourceBlockchain) {
+	for _, relayerID := range database.GetSourceBlockchainRelayerIDs(sourceBlockchain) {
 		logger = logger.With(
 			zap.Stringer("relayerID", relayerID.ID),
 			zap.Stringer("destinationBlockchainID", relayerID.DestinationBlockchainID),

--- a/relayer/message_coordinator.go
+++ b/relayer/message_coordinator.go
@@ -59,14 +59,15 @@ func (mc *MessageCoordinator) getAppRelayerMessageHandler(
 	error,
 ) {
 	// Check that the warp message is from a supported message protocol contract address.
+	protocolAddress := warpMessageInfo.SourceAddress
 	//nolint:lll
-	messageHandlerFactory, supportedMessageProtocol := mc.messageHandlerFactories[warpMessageInfo.UnsignedMessage.SourceChainID][warpMessageInfo.SourceAddress]
+	messageHandlerFactory, supportedMessageProtocol := mc.messageHandlerFactories[warpMessageInfo.UnsignedMessage.SourceChainID][protocolAddress]
 	if !supportedMessageProtocol {
 		// Do not return an error here because it is expected for there to be messages from other contracts
 		// than just the ones supported by a single listener instance.
 		mc.logger.Debug(
 			"Warp message from unsupported message protocol address. Not relaying.",
-			zap.Stringer("protocolAddress", warpMessageInfo.SourceAddress),
+			zap.Stringer("protocolAddress", protocolAddress),
 		)
 		return nil, nil, nil
 	}
@@ -77,6 +78,7 @@ func (mc *MessageCoordinator) getAppRelayerMessageHandler(
 	}
 
 	appRelayer := mc.getApplicationRelayer(
+		protocolAddress,
 		routeInfo.SourceChainID,
 		routeInfo.SenderAddress,
 		routeInfo.DestinationChainID,
@@ -117,6 +119,7 @@ func (mc *MessageCoordinator) getAppRelayerMessageHandler(
 // 4. A match on sourceBlockchainID and destinationBlockchainID, with any originSenderAddress and any
 // destinationAddress
 func (mc *MessageCoordinator) getApplicationRelayer(
+	protocolAddress common.Address,
 	sourceBlockchainID ids.ID,
 	originSenderAddress common.Address,
 	destinationBlockchainID ids.ID,
@@ -124,6 +127,7 @@ func (mc *MessageCoordinator) getApplicationRelayer(
 ) *ApplicationRelayer {
 	// Check for an exact match
 	applicationRelayerID := database.CalculateRelayerID(
+		protocolAddress,
 		sourceBlockchainID,
 		destinationBlockchainID,
 		originSenderAddress,
@@ -136,6 +140,7 @@ func (mc *MessageCoordinator) getApplicationRelayer(
 	// Check for a match on sourceBlockchainID and destinationBlockchainID, with a specific
 	// originSenderAddress and any destinationAddress.
 	applicationRelayerID = database.CalculateRelayerID(
+		protocolAddress,
 		sourceBlockchainID,
 		destinationBlockchainID,
 		originSenderAddress,
@@ -148,6 +153,7 @@ func (mc *MessageCoordinator) getApplicationRelayer(
 	// Check for a match on sourceBlockchainID and destinationBlockchainID, with any originSenderAddress
 	// and a specific destinationAddress.
 	applicationRelayerID = database.CalculateRelayerID(
+		protocolAddress,
 		sourceBlockchainID,
 		destinationBlockchainID,
 		database.AllAllowedAddress,
@@ -160,6 +166,7 @@ func (mc *MessageCoordinator) getApplicationRelayer(
 	// Check for a match on sourceBlockchainID and destinationBlockchainID, with any originSenderAddress
 	// and any destinationAddress.
 	applicationRelayerID = database.CalculateRelayerID(
+		protocolAddress,
 		sourceBlockchainID,
 		destinationBlockchainID,
 		database.AllAllowedAddress,


### PR DESCRIPTION
## Why this should be merged
Adds the `ProtocolAddress` to the `ApplicationRelayer`. This allows us to have separate `ApplicationRelayer`s and separate checkpointing per `TeleporterMessenger` V1 and V2 contracts.

## How this works

## How this was tested

## How is this documented