### PR TITLE
1 listener per protocol address

### DIFF
--- a/relayer/listener.go
+++ b/relayer/listener.go
@@ -40,6 +40,7 @@ type Listener struct {
 	maxConcurrentMsg             uint64
 	errChan                      chan error
 	lastSubscriberBlockProcessed uint64
+	protocolAddr                 common.Address
 }
 
 // RunListener creates a Listener instance and the ApplicationRelayers for a subnet.
@@ -47,6 +48,7 @@ type Listener struct {
 func RunListener(
 	ctx context.Context,
 	logger logging.Logger,
+	protocolAddr common.Address,
 	sourceBlockchain config.SourceBlockchain,
 	ethRPCClient *ethclient.Client,
 	relayerHealth *atomic.Bool,
@@ -64,6 +66,7 @@ func RunListener(
 	listener, err := newListener(
 		ctx,
 		logger,
+		protocolAddr,
 		sourceBlockchain,
 		ethRPCClient,
 		relayerHealth,
@@ -85,6 +88,7 @@ func RunListener(
 func newListener(
 	ctx context.Context,
 	logger logging.Logger,
+	protocolAddr common.Address,
 	sourceBlockchain config.SourceBlockchain,
 	ethRPCClient *ethclient.Client,
 	relayerHealth *atomic.Bool,
@@ -114,7 +118,7 @@ func newListener(
 		ethWSClient,
 		ethRPCClient,
 		errChan,
-		[][]common.Hash{{types.WarpPrecompileLogFilter}, { /* TODO Teleporter Addr */ }},
+		[][]common.Hash{{types.WarpPrecompileLogFilter}, {common.BytesToHash(protocolAddr[:])}},
 	)
 
 	logger.Info("Creating relayer")
@@ -129,6 +133,7 @@ func newListener(
 		messageCoordinator:           messageCoordinator,
 		maxConcurrentMsg:             maxConcurrentMsg,
 		lastSubscriberBlockProcessed: startingHeight - 1,
+		protocolAddr:                 protocolAddr,
 	}
 
 	// Open the subscription. We must do this before processing any missed messages, otherwise we may

--- a/relayer/listener.go
+++ b/relayer/listener.go
@@ -61,6 +61,7 @@ func RunListener(
 		zap.String("subnetIDHex", sourceBlockchain.GetSubnetID().Hex()),
 		zap.Stringer("blockchainID", sourceBlockchain.GetBlockchainID()),
 		zap.String("blockchainIDHex", sourceBlockchain.GetBlockchainID().Hex()),
+		zap.String("protocolAddress", protocolAddr.String()),
 	)
 	// Create the Listener
 	listener, err := newListener(

--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -327,25 +327,32 @@ func main() {
 
 	// Create listeners for each of the subnets configured as a source
 	for _, sourceBlockchain := range cfg.SourceBlockchains {
-		// errgroup will cancel the context when the first goroutine returns an error
-		errGroup.Go(func() error {
-			log := logger.With(zap.Stringer("sourceBlockchainID", sourceBlockchain.GetBlockchainID()))
-			// runListener runs until it errors or the context is canceled by another goroutine
-			err := relayer.RunListener(
-				ctx,
-				log,
-				*sourceBlockchain,
-				sourceClients[sourceBlockchain.GetBlockchainID()],
-				relayerHealth[sourceBlockchain.GetBlockchainID()],
-				minHeights[sourceBlockchain.GetBlockchainID()],
-				messageCoordinator,
-				cfg.MaxConcurrentMessages,
-			)
-			if err != nil {
-				log.Error("error running listener", zap.Error(err))
-			}
-			return err
-		})
+		for _, protocolAddr := range sourceBlockchain.ProtocolAddresses() {
+			// errgroup will cancel the context when the first goroutine returns an error
+			errGroup.Go(func() error {
+				log := logger.With(
+					zap.Stringer("sourceBlockchainID", sourceBlockchain.GetBlockchainID()),
+					zap.Stringer("subnetID", sourceBlockchain.GetSubnetID()),
+					zap.String("protocolAddress", protocolAddr.String()),
+				)
+				// runListener runs until it errors or the context is canceled by another goroutine
+				err := relayer.RunListener(
+					ctx,
+					log,
+					protocolAddr,
+					*sourceBlockchain,
+					sourceClients[sourceBlockchain.GetBlockchainID()],
+					relayerHealth[sourceBlockchain.GetBlockchainID()],
+					minHeights[sourceBlockchain.GetBlockchainID()],
+					messageCoordinator,
+					cfg.MaxConcurrentMessages,
+				)
+				if err != nil {
+					log.Error("error running listener", zap.Error(err))
+				}
+				return err
+			})
+		}
 	}
 
 	// Start validator set updaters for configured external EVM destinations

--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -330,15 +330,10 @@ func main() {
 		for _, protocolAddr := range sourceBlockchain.ProtocolAddresses() {
 			// errgroup will cancel the context when the first goroutine returns an error
 			errGroup.Go(func() error {
-				log := logger.With(
-					zap.Stringer("sourceBlockchainID", sourceBlockchain.GetBlockchainID()),
-					zap.Stringer("subnetID", sourceBlockchain.GetSubnetID()),
-					zap.String("protocolAddress", protocolAddr.String()),
-				)
 				// runListener runs until it errors or the context is canceled by another goroutine
-				err := relayer.RunListener(
+				return relayer.RunListener(
 					ctx,
-					log,
+					logger,
 					protocolAddr,
 					*sourceBlockchain,
 					sourceClients[sourceBlockchain.GetBlockchainID()],
@@ -347,10 +342,6 @@ func main() {
 					messageCoordinator,
 					cfg.MaxConcurrentMessages,
 				)
-				if err != nil {
-					log.Error("error running listener", zap.Error(err))
-				}
-				return err
 			})
 		}
 	}


### PR DESCRIPTION
## Why this should be merged
Creates 1 listener/subscriber per protocol address, and the listener will filter events based on the protocol address.

## How this works

## How this was tested

## How is this documented