### PR TITLE
Implement EventFilterForProtocol

### DIFF
--- a/database/relayer_id.go
+++ b/database/relayer_id.go
@@ -110,7 +110,7 @@ func GetSourceBlockchainRelayerIDs(sourceBlockchain *config.SourceBlockchain) []
 	if len(srcAddresses) == 0 {
 		srcAddresses = append(srcAddresses, AllAllowedAddress)
 	}
-	for _, protocolAddress := range sourceBlockchain.ProtocolAddresses() {
+	for _, protocol := range sourceBlockchain.Protocols() {
 		for _, srcAddress := range srcAddresses {
 			for _, dst := range sourceBlockchain.SupportedDestinations {
 				dstAddresses := dst.GetAddresses()
@@ -120,7 +120,7 @@ func GetSourceBlockchainRelayerIDs(sourceBlockchain *config.SourceBlockchain) []
 				}
 				for _, dstAddress := range dstAddresses {
 					ids = append(ids, NewRelayerID(
-						protocolAddress,
+						protocol.Address,
 						sourceBlockchain.GetBlockchainID(),
 						dst.GetBlockchainID(),
 						srcAddress,

--- a/relayer/config/source_blockchain.go
+++ b/relayer/config/source_blockchain.go
@@ -64,8 +64,8 @@ func (s *SourceBlockchain) Validate(destinationBlockchainIDs *set.Set[string]) e
 			return fmt.Errorf("unsupported message protocol for source subnet: %s", messageConfig.MessageFormat)
 		}
 		s.protocols = append(s.protocols, Protocol{
-			Address:  common.HexToAddress(messageContractAddress),
-			Protocol: protocol,
+			Address: common.HexToAddress(messageContractAddress),
+			Type:    protocol,
 		})
 	}
 

--- a/relayer/config/source_blockchain.go
+++ b/relayer/config/source_blockchain.go
@@ -28,7 +28,7 @@ type SourceBlockchain struct {
 	WarpAPIEndpoint basecfg.APIConfig `mapstructure:"warp-api-endpoint" json:"warp-api-endpoint"` //nolint:lll
 
 	// convenience fields to access parsed data after initialization
-	protocolAddresses            []common.Address
+	protocols                    []Protocol
 	subnetID                     ids.ID
 	blockchainID                 ids.ID
 	allowedOriginSenderAddresses []common.Address
@@ -54,20 +54,19 @@ func (s *SourceBlockchain) Validate(destinationBlockchainIDs *set.Set[string]) e
 		s.useAppRequestNetwork = true
 	}
 
-	// Validate the EVM settings
-	for messageContractAddress := range s.MessageContracts {
+	// Validate the EVM settings and message protocol for each contract
+	for messageContractAddress, messageConfig := range s.MessageContracts {
 		if !common.IsHexAddress(messageContractAddress) {
 			return fmt.Errorf("invalid message contract address in EVM source subnet: %s", messageContractAddress)
 		}
-		s.protocolAddresses = append(s.protocolAddresses, common.HexToAddress(messageContractAddress))
-	}
-
-	// Validate message settings correspond to a supported message protocol
-	for _, messageConfig := range s.MessageContracts {
 		protocol := ParseMessageProtocol(messageConfig.MessageFormat)
 		if protocol == UNKNOWN_MESSAGE_PROTOCOL {
 			return fmt.Errorf("unsupported message protocol for source subnet: %s", messageConfig.MessageFormat)
 		}
+		s.protocols = append(s.protocols, Protocol{
+			Address:  common.HexToAddress(messageContractAddress),
+			Protocol: protocol,
+		})
 	}
 
 	// Validate and store the subnet and blockchain IDs for future use
@@ -160,8 +159,8 @@ func (s *SourceBlockchain) UseAppRequestNetwork() bool {
 	return s.useAppRequestNetwork
 }
 
-func (s *SourceBlockchain) ProtocolAddresses() []common.Address {
-	return s.protocolAddresses
+func (s *SourceBlockchain) Protocols() []Protocol {
+	return s.protocols
 }
 
 // Specifies a supported destination blockchain and addresses for a source blockchain.

--- a/relayer/config/types.go
+++ b/relayer/config/types.go
@@ -3,6 +3,14 @@
 
 package config
 
+import "github.com/ava-labs/libevm/common"
+
+// Protocol pairs a contract address with the message protocol it implements.
+type Protocol struct {
+	Address  common.Address
+	Protocol MessageProtocol
+}
+
 // Supported Message Protocols
 type MessageProtocol int
 

--- a/relayer/config/types.go
+++ b/relayer/config/types.go
@@ -7,8 +7,8 @@ import "github.com/ava-labs/libevm/common"
 
 // Protocol pairs a contract address with the message protocol it implements.
 type Protocol struct {
-	Address  common.Address
-	Protocol MessageProtocol
+	Address common.Address
+	Type    MessageProtocol
 }
 
 // Supported Message Protocols

--- a/relayer/listener.go
+++ b/relayer/listener.go
@@ -28,6 +28,25 @@ const (
 	retryResubscribeTimeout = 10 * time.Second
 )
 
+// EventFilterForProtocol returns the ethereum log filter topics for the given protocol and
+// contract address. Returns nil for protocols that do not use a listener.
+func EventFilterForProtocol(
+	protocol config.MessageProtocol,
+	address common.Address,
+) [][]common.Hash {
+	switch protocol {
+	case config.TELEPORTER:
+		return [][]common.Hash{
+			{types.WarpPrecompileLogFilter},
+			{common.BytesToHash(address[:])},
+		}
+	case config.TELEPORTER_V2:
+		panic("teleporter v2 is not yet supported")
+	default:
+		panic("unsupported protocol")
+	}
+}
+
 // Listener handles all messages sent from a given source chain
 type Listener struct {
 	Subscriber                   *evm.Subscriber
@@ -40,7 +59,7 @@ type Listener struct {
 	maxConcurrentMsg             uint64
 	errChan                      chan error
 	lastSubscriberBlockProcessed uint64
-	protocolAddr                 common.Address
+	protocol                     config.Protocol
 }
 
 // RunListener creates a Listener instance and the ApplicationRelayers for a subnet.
@@ -48,7 +67,7 @@ type Listener struct {
 func RunListener(
 	ctx context.Context,
 	logger logging.Logger,
-	protocolAddr common.Address,
+	protocol config.Protocol,
 	sourceBlockchain config.SourceBlockchain,
 	ethRPCClient *ethclient.Client,
 	relayerHealth *atomic.Bool,
@@ -61,13 +80,13 @@ func RunListener(
 		zap.String("subnetIDHex", sourceBlockchain.GetSubnetID().Hex()),
 		zap.Stringer("blockchainID", sourceBlockchain.GetBlockchainID()),
 		zap.String("blockchainIDHex", sourceBlockchain.GetBlockchainID().Hex()),
-		zap.String("protocolAddress", protocolAddr.String()),
+		zap.String("protocolAddress", protocol.Address.String()),
 	)
 	// Create the Listener
 	listener, err := newListener(
 		ctx,
 		logger,
-		protocolAddr,
+		protocol,
 		sourceBlockchain,
 		ethRPCClient,
 		relayerHealth,
@@ -89,7 +108,7 @@ func RunListener(
 func newListener(
 	ctx context.Context,
 	logger logging.Logger,
-	protocolAddr common.Address,
+	protocol config.Protocol,
 	sourceBlockchain config.SourceBlockchain,
 	ethRPCClient *ethclient.Client,
 	relayerHealth *atomic.Bool,
@@ -119,7 +138,7 @@ func newListener(
 		ethWSClient,
 		ethRPCClient,
 		errChan,
-		[][]common.Hash{{types.WarpPrecompileLogFilter}, {common.BytesToHash(protocolAddr[:])}},
+		EventFilterForProtocol(protocol.Protocol, protocol.Address),
 	)
 
 	logger.Info("Creating relayer")
@@ -134,7 +153,7 @@ func newListener(
 		messageCoordinator:           messageCoordinator,
 		maxConcurrentMsg:             maxConcurrentMsg,
 		lastSubscriberBlockProcessed: startingHeight - 1,
-		protocolAddr:                 protocolAddr,
+		protocol:                     protocol,
 	}
 
 	// Open the subscription. We must do this before processing any missed messages, otherwise we may

--- a/relayer/listener.go
+++ b/relayer/listener.go
@@ -28,17 +28,13 @@ const (
 	retryResubscribeTimeout = 10 * time.Second
 )
 
-// EventFilterForProtocol returns the ethereum log filter topics for the given protocol and
-// contract address. Returns nil for protocols that do not use a listener.
-func EventFilterForProtocol(
-	protocol config.MessageProtocol,
-	address common.Address,
-) [][]common.Hash {
-	switch protocol {
+// EventFilterForProtocol returns the ethereum log filter topics for the given protocol and contract address.
+func EventFilterForProtocol(protocol config.Protocol) [][]common.Hash {
+	switch protocol.Type {
 	case config.TELEPORTER:
 		return [][]common.Hash{
 			{types.WarpPrecompileLogFilter},
-			{common.BytesToHash(address[:])},
+			{common.BytesToHash(protocol.Address[:])},
 		}
 	case config.TELEPORTER_V2:
 		panic("teleporter v2 is not yet supported")
@@ -138,7 +134,7 @@ func newListener(
 		ethWSClient,
 		ethRPCClient,
 		errChan,
-		EventFilterForProtocol(protocol.Protocol, protocol.Address),
+		EventFilterForProtocol(protocol),
 	)
 
 	logger.Info("Creating relayer")

--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -23,8 +23,6 @@ import (
 	subsetupdater "github.com/ava-labs/icm-services/abi-bindings/go/SubsetUpdater"
 	"github.com/ava-labs/icm-services/database"
 	"github.com/ava-labs/icm-services/messages"
-	offchainregistry "github.com/ava-labs/icm-services/messages/off-chain-registry"
-	"github.com/ava-labs/icm-services/messages/teleporter"
 	metricsServer "github.com/ava-labs/icm-services/metrics"
 	"github.com/ava-labs/icm-services/peers"
 	"github.com/ava-labs/icm-services/peers/clients"
@@ -327,14 +325,18 @@ func main() {
 
 	// Create listeners for each of the subnets configured as a source
 	for _, sourceBlockchain := range cfg.SourceBlockchains {
-		for _, protocolAddr := range sourceBlockchain.ProtocolAddresses() {
+		for _, protocol := range sourceBlockchain.Protocols() {
+			// We don't need to spawn a listener for the off-chain registry.
+			if protocol.Protocol == config.OFF_CHAIN_REGISTRY {
+				continue
+			}
 			// errgroup will cancel the context when the first goroutine returns an error
 			errGroup.Go(func() error {
 				// runListener runs until it errors or the context is canceled by another goroutine
 				return relayer.RunListener(
 					ctx,
 					logger,
-					protocolAddr,
+					protocol,
 					*sourceBlockchain,
 					sourceClients[sourceBlockchain.GetBlockchainID()],
 					relayerHealth[sourceBlockchain.GetBlockchainID()],
@@ -437,30 +439,7 @@ func createMessageHandlerFactories(
 		// Create message handler factories for each supported message protocol
 		for addressStr, cfg := range sourceBlockchain.MessageContracts {
 			address := common.HexToAddress(addressStr)
-			format := cfg.MessageFormat
-			var (
-				m   messages.MessageHandlerFactory
-				err error
-			)
-			switch config.ParseMessageProtocol(format) {
-			case config.TELEPORTER:
-				m, err = teleporter.NewMessageHandlerFactory(
-					address,
-					cfg,
-					deciderConnection,
-				)
-			case config.OFF_CHAIN_REGISTRY:
-				m, err = offchainregistry.NewMessageHandlerFactory(cfg)
-			case config.TELEPORTER_V2:
-				// m, err = teleporterv2.NewMessageHandlerFactory(
-				// 	address,
-				// 	cfg,
-				// 	deciderConnection,
-				// )
-				err = fmt.Errorf("teleporter v2 is not yet supported")
-			default:
-				m, err = nil, fmt.Errorf("invalid message format %s", format)
-			}
+			m, err := relayer.NewMessageHandlerFactory(address, cfg, deciderConnection)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create message handler factory: %w", err)
 			}

--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -327,7 +327,7 @@ func main() {
 	for _, sourceBlockchain := range cfg.SourceBlockchains {
 		for _, protocol := range sourceBlockchain.Protocols() {
 			// We don't need to spawn a listener for the off-chain registry.
-			if protocol.Protocol == config.OFF_CHAIN_REGISTRY {
+			if protocol.Type == config.OFF_CHAIN_REGISTRY {
 				continue
 			}
 			// errgroup will cancel the context when the first goroutine returns an error

--- a/relayer/message_handler_factory.go
+++ b/relayer/message_handler_factory.go
@@ -1,0 +1,34 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package relayer
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/icm-services/messages"
+	offchainregistry "github.com/ava-labs/icm-services/messages/off-chain-registry"
+	"github.com/ava-labs/icm-services/messages/teleporter"
+	"github.com/ava-labs/icm-services/relayer/config"
+	"github.com/ava-labs/libevm/common"
+	"google.golang.org/grpc"
+)
+
+// NewMessageHandlerFactory returns the MessageHandlerFactory for the protocol identified
+// by cfg.MessageFormat. Returns an error for unknown or unsupported protocols.
+func NewMessageHandlerFactory(
+	address common.Address,
+	cfg config.MessageProtocolConfig,
+	deciderConnection *grpc.ClientConn,
+) (messages.MessageHandlerFactory, error) {
+	switch config.ParseMessageProtocol(cfg.MessageFormat) {
+	case config.TELEPORTER:
+		return teleporter.NewMessageHandlerFactory(address, cfg, deciderConnection)
+	case config.OFF_CHAIN_REGISTRY:
+		return offchainregistry.NewMessageHandlerFactory(cfg)
+	case config.TELEPORTER_V2:
+		return nil, fmt.Errorf("teleporter v2 is not yet supported")
+	default:
+		return nil, fmt.Errorf("invalid message format %s", cfg.MessageFormat)
+	}
+}


### PR DESCRIPTION
## Why this should be merged
Passes the Protocol type to the application relayer/listener so that it can decide how to listen to events. The protocol will also be used to parse/dispatch messages separately for TeleporterV2 in a followup PR

## How this works

## How this was tested

## How is this documented