### PR TITLE
Added support for asserts on deserialized data

### DIFF
--- a/icm-macros/README.md
+++ b/icm-macros/README.md
@@ -115,8 +115,20 @@ struct MyStruct {
 | `contract` | key-value | Name of the contract/library to inject the generated function into. | *(none — free-standing)* |
 | `name` | key-value | Override the generated function name. | `unpack{TypeName}` |
 | `visibility` | key-value | Visibility of the generated function. | `public` |
+| `assert = "\|var\| { expr }"` | key-value | Emit `require(expr)` before the function returns, with `var` replaced by `result` (the decoded struct). May appear multiple times. Not valid on enums. | *(none)* |
 | `calldata` | flag | Accept `bytes calldata data` instead of `bytes memory data`. | *(off)* |
 | `solhint-disable` | flag | Wrap the generated function with `// solhint-disable no-inline-assembly` / `// solhint-enable no-inline-assembly`. | *(off)* |
+
+The closure value must be a quoted string so that commas and `=` signs inside the expression are not misinterpreted as argument separators. Example:
+
+```solidity
+// #[unpack(
+//    calldata,
+//    assert = "|s| { s.length > 0 }",
+//    assert = "|s| { s.field == s.other }",
+//  )]
+struct MyStruct { ... }
+```
 
 #### Field-level annotations
 
@@ -127,6 +139,8 @@ struct MyStruct {
 | `#[unpack(length = uintN)]` | Override the length/count prefix type for `bytes`, `string`, or array fields. Must match the type used by the corresponding `#[pack(length = uintN)]`. Defaults to `uint256`. |
 | `#[unpack(length = constant)]` | No prefix is read; instead `constant` is used as the field length/element count. Pairs with `#[pack(length = drop)]`. `constant` can be any Solidity expression (e.g. `32`, `BLST.SIG_LENGTH`). |
 | `#[unpack(method = "expr", length = constant)]` | Pass a pre-sliced buffer of exactly `constant` bytes to `expr`. The method returns just the field value (no bytes-consumed count); the macro advances `data` by `constant` bytes. Use for fixed-size fields decoded by a helper that does not follow the `(uint256, T)` unpack convention. |
+| `#[unpack(assert = "\|var\| { expr }")]` | Emit `require(expr)` immediately after the field is assigned to `result`, with `var` replaced by the field's local variable name. May appear multiple times. |
+| `#[unpack(assert = "\|each var\| { expr }")]` | Assert a condition on each element of a container field. For **arrays**, `var` is replaced by the per-element local inside the decode loop. For **`bytes`/`string`/`bytesN`**, a post-decode loop iterates the bytes and binds `bytes1 _elem`; `var` is replaced by `_elem`. Not valid on non-container types. |
 
 #### Primitive field decoding
 

--- a/icm-macros/src/pack.rs
+++ b/icm-macros/src/pack.rs
@@ -26,6 +26,13 @@
 //! `visibility`: If provided, the visibility of the function will be set to this value. The default
 //! is `public`.
 //!
+//! `assert`: Provide a closure of the form `|b| {...} -> bool` to assert some post-condition on the
+//! serialized data.
+//!
+//! `solhint-disable` (flag): Wrap the generated function with
+//! `// solhint-disable no-inline-assembly` / `// solhint-enable no-inline-assembly` comments.
+//! Use this when the project enforces the solhint `no-inline-assembly` rule.
+//!
 //! _Fields_
 //! As mentioned above, each non-primitive field is assumed to also possess a pack method. This is
 //! assumed to be in the scope in which the macro-expanded code will be placed.  To override this
@@ -38,8 +45,8 @@
 //!  Intended for use alongside `#[unpack(ignore)]`.
 //!
 //! `#[pack(length = drop|constant)]`: If a field is a dynamically sized type, by default its length
-//! will be encoded using a uint256. This can be changed to use a different solidity unsigned integer
-//! type. If the size is a constant, the drop keyword can be used to avoid encoding the length.
+//!  will be encoded using a uint256. This can be changed to use a different solidity unsigned integer
+//!  type. If the size is a constant, the drop keyword can be used to avoid encoding the length.
 //!
 //!
 //! _Arrays_

--- a/icm-macros/src/unpack.rs
+++ b/icm-macros/src/unpack.rs
@@ -26,6 +26,11 @@
 //!
 //! `visibility`: Set the visibility of the generated function. Defaults to `public`.
 //!
+//! `assert = "|var| { expr }"`: Assert a post-condition on the fully-deserialized struct. The
+//! closure value must be a quoted string. `var` is replaced with `result` (the decoded struct) in
+//! the emitted `require` expression. Multiple `assert` keys may appear; each generates a separate
+//! `require` call emitted just before the function's `return` statement. Not valid on enums.
+//!
 //! `calldata` (flag): Accept `bytes calldata data` instead of `bytes memory data`. The generated
 //! code uses calldata array slices throughout, avoiding any memory allocation for the buffer itself.
 //!
@@ -51,6 +56,16 @@
 //! bytes to `expr`. The method returns just the field value (no bytes-consumed count); the macro
 //! advances `data` by `constant` bytes. Use this for fixed-size fields decoded by a helper that
 //! does not implement the `(uint256, T)` unpack convention.
+//!
+//! `assert = "|var| { expr }"`: Assert a post-condition on the decoded field value. `var` is
+//! replaced with the field's local variable name. Emitted as `require(expr)` immediately after
+//! `result.field = local`. Multiple `assert` keys may appear on a single field.
+//!
+//! `assert = "|each var| { expr }"`: Assert a post-condition on each element of a container field
+//! (array, `bytes`, `string`, or `bytesN`). For arrays, `var` is replaced with the per-element
+//! local inside the decode loop. For `bytes`/`string`/`bytesN`, a post-decode loop iterates the
+//! bytes and binds `bytes1 _elem`; `var` is replaced with `_elem`. Not valid on non-container
+//! types or at the type level.
 //!
 //! _Arrays_
 //! Arrays are supported by the macro. The macro will walk the array's elements and call the unpack
@@ -184,7 +199,8 @@ pub fn derive_unpack(
 
         let type_name =
             qualified_type_name(ctx, enum_def.name.as_str(), enum_def.contract, arg.contract);
-        let code = methods::unpack_enum(enum_def, arg, &type_name);
+        let code = methods::unpack_enum(enum_def, arg, &type_name)
+            .map_err(foundry_compilers::error::SolcError::msg)?;
 
         let path = ctx
             .sources
@@ -239,6 +255,22 @@ mod tests {
             (
                 "testing/unpack/errors/BadContract.sol",
                 "contract `NonExistent` specified in #[unpack(contract=...)] was not found",
+            ),
+            (
+                "testing/unpack/errors/EachOnStruct.sol",
+                "`each` assert on `HasEachAssert` is not valid at the type level: structs are not container types",
+            ),
+            (
+                "testing/unpack/errors/EachOnEnum.sol",
+                "`each` assert on `HasEachAssert` is not valid: enums are not container types",
+            ),
+            (
+                "testing/unpack/errors/EachOnNonContainer.sol",
+                "`each` assert on `value` requires a container type (array, bytes, string, or bytesN), not `uint256`",
+            ),
+            (
+                "testing/unpack/errors/EachOnCustom.sol",
+                "`each` assert on `inner` requires a container type (array, bytes, string, or bytesN), not `Inner`",
             ),
         ];
         for (path, expected) in cases {

--- a/icm-macros/src/unpack/hooks.rs
+++ b/icm-macros/src/unpack/hooks.rs
@@ -14,6 +14,9 @@ pub struct UnpackArgs {
     pub visibility: String,
     pub calldata: bool,
     pub solhint_disable: bool,
+    /// Type-level post-condition. The capture name is replaced with `result`
+    /// (the decoded struct) in the assertion body.
+    pub assert: Vec<AssertDef>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -24,12 +27,28 @@ pub enum LengthSpec {
     Constant(String),
 }
 
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum CaptureType {
+    Element,
+    #[default]
+    Field,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AssertDef {
+    pub captured: CaptureType,
+    pub var: String,
+    pub expr: String,
+}
+
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct FieldArgs {
     pub method: Option<String>,
     pub default: bool,
     pub memory: bool,
     pub length: Option<LengthSpec>,
+    /// Field-level post-conditions.
+    pub assert: Vec<AssertDef>,
 }
 
 /// Intermediate parsed args before HIR resolution. Contract is stored as a name
@@ -41,6 +60,7 @@ pub(crate) struct RawUnpackArgs {
     pub visibility: String,
     pub calldata: bool,
     pub solhint_disable: bool,
+    pub assert: Vec<AssertDef>,
 }
 
 /// Fetches the comment preceding the given HIR item and parses any `#[unpack(...)]`
@@ -101,6 +121,7 @@ pub fn parse_args(
         visibility: raw.visibility,
         calldata: raw.calldata,
         solhint_disable: raw.solhint_disable,
+        assert: raw.assert,
     }))
 }
 
@@ -113,16 +134,17 @@ pub(crate) fn parse_comment(
 ) -> Option<RawUnpackArgs> {
     let pack_start = comment.find("#[unpack(")?;
     let args_start = pack_start + "#[unpack(".len();
-    let args_end = args_start + comment[args_start..].find(')')?;
-    let args_str = &comment[args_start..args_end];
+    let args_end = args_start + find_closing_paren(&comment[args_start..])?;
+    let args_str = strip_comment_prefixes(&comment[args_start..args_end]);
 
     let mut contract = None;
     let mut name = None;
     let mut visibility = "public".to_string();
     let mut calldata = false;
     let mut solhint_disable = false;
+    let mut asserts: Vec<AssertDef> = Vec::new();
 
-    for pair in args_str.split(',') {
+    for pair in split_args(&args_str) {
         let pair = pair.trim();
         if let Some((key, val)) = pair.split_once('=') {
             let val = val.trim().trim_matches('"');
@@ -130,6 +152,15 @@ pub(crate) fn parse_comment(
                 "contract" => contract = Some(val.to_string()),
                 "name" => name = Some(val.to_string()),
                 "visibility" => visibility = val.to_string(),
+                "assert" => {
+                    if let Some((captured, var, expr)) = parse_closure(val) {
+                        asserts.push(AssertDef {
+                            captured,
+                            var,
+                            expr,
+                        });
+                    }
+                }
                 _ => {}
             }
         } else {
@@ -153,6 +184,7 @@ pub(crate) fn parse_comment(
         visibility,
         calldata,
         solhint_disable,
+        assert: asserts,
     })
 }
 
@@ -168,44 +200,38 @@ fn type_requires_memory(ty: &Type) -> bool {
 fn parse_field_args(comment: Option<&str>, memory: bool) -> FieldArgs {
     let Some(comment) = comment else {
         return FieldArgs {
-            method: None,
-            default: false,
             memory,
-            length: None,
+            ..Default::default()
         };
     };
     let Some(pack_start) = comment.find("#[unpack(") else {
         return FieldArgs {
-            method: None,
-            default: false,
             memory,
-            length: None,
+            ..Default::default()
         };
     };
     let args_start = pack_start + "#[unpack(".len();
-    let Some(args_end_rel) = comment[args_start..].find(')') else {
+    let Some(args_end_rel) = find_closing_paren(&comment[args_start..]) else {
         return FieldArgs {
-            method: None,
-            default: false,
             memory,
-            length: None,
+            ..Default::default()
         };
     };
-    let args_str = comment[args_start..args_start + args_end_rel].trim();
+    let args_str = strip_comment_prefixes(comment[args_start..args_start + args_end_rel].trim());
 
     if args_str == "default" {
         return FieldArgs {
-            method: None,
             default: true,
             memory,
-            length: None,
+            ..Default::default()
         };
     }
 
     let mut method = None;
     let mut default = false;
     let mut length = None;
-    for arg in args_str.split(',') {
+    let mut asserts: Vec<AssertDef> = Vec::new();
+    for arg in split_args(&args_str) {
         if let Some((key, val)) = arg.trim().split_once('=') {
             match key.trim() {
                 "method" => method = Some(val.trim().trim_matches('"').to_string()),
@@ -221,6 +247,16 @@ fn parse_field_args(comment: Option<&str>, memory: bool) -> FieldArgs {
                         LengthSpec::Constant(v.to_string())
                     });
                 }
+                "assert" => {
+                    let inner = val.trim().trim_matches('"');
+                    if let Some((captured, var, expr)) = parse_closure(inner) {
+                        asserts.push(AssertDef {
+                            captured,
+                            var,
+                            expr,
+                        });
+                    }
+                }
                 _ => {}
             }
         } else if arg.trim() == "default" {
@@ -229,10 +265,9 @@ fn parse_field_args(comment: Option<&str>, memory: bool) -> FieldArgs {
     }
     if default {
         FieldArgs {
-            method: None,
             default: true,
             memory,
-            length: None,
+            ..Default::default()
         }
     } else {
         FieldArgs {
@@ -240,8 +275,151 @@ fn parse_field_args(comment: Option<&str>, memory: bool) -> FieldArgs {
             default: false,
             memory,
             length,
+            assert: asserts,
         }
     }
+}
+
+/// Strips comment-line prefixes (`//`, `///`, `*`) from a multi-line args string.
+///
+/// When `#[unpack(...)]` spans multiple lines each continuation line begins
+/// with a comment prefix that must be removed before parsing keys and values.
+/// Handles both formats that `reforge::get_comment` may produce:
+///   - Newline-separated: `"\n//    arg1,\n//    arg2"`
+///   - Concatenated (no newlines): `"//    arg1,//    arg2"`
+///
+/// Splits on `\n` and on `//` occurrences outside quoted strings, strips
+/// leading whitespace and `*` block-comment markers from each segment, drops
+/// empty segments, and joins the results with a single space.
+fn strip_comment_prefixes(s: &str) -> String {
+    let mut segments: Vec<&str> = Vec::new();
+    let mut seg_start = 0;
+    let mut in_quotes = false;
+    let bytes = s.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' => {
+                in_quotes = !in_quotes;
+                i += 1;
+            }
+            b'\n' if !in_quotes => {
+                segments.push(&s[seg_start..i]);
+                i += 1;
+                seg_start = i;
+            }
+            b'/' if !in_quotes && i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
+                segments.push(&s[seg_start..i]);
+                i += 2;
+                // skip optional third slash (///)
+                if i < bytes.len() && bytes[i] == b'/' {
+                    i += 1;
+                }
+                seg_start = i;
+            }
+            _ => i += 1,
+        }
+    }
+    segments.push(&s[seg_start..]);
+
+    segments
+        .iter()
+        .filter_map(|seg| {
+            let t = seg.trim_start();
+            let t = if let Some(r) = t.strip_prefix('*') {
+                r.trim_start()
+            } else {
+                t
+            };
+            if t.is_empty() { None } else { Some(t) }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Finds the index of the `)` that closes the current paren level, skipping
+/// over any nested `(...)` pairs and `"..."` quoted strings.
+/// Returns `None` if no such `)` exists.
+fn find_closing_paren(s: &str) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut in_quotes = false;
+    for (i, c) in s.char_indices() {
+        match c {
+            '"' => in_quotes = !in_quotes,
+            '(' if !in_quotes => depth += 1,
+            ')' if !in_quotes => {
+                if depth == 0 {
+                    return Some(i);
+                }
+                depth -= 1;
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Splits `s` on commas that are outside of `"..."` quoted strings.
+fn split_args(s: &str) -> Vec<&str> {
+    let mut result = Vec::new();
+    let mut start = 0;
+    let mut in_quotes = false;
+    for (i, c) in s.char_indices() {
+        match c {
+            '"' => in_quotes = !in_quotes,
+            ',' if !in_quotes => {
+                result.push(&s[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    result.push(&s[start..]);
+    result
+}
+
+/// Parses a closure of the form `|[each] capture| { body }`.
+/// The `each` keyword (e.g. `|each x|`) sets `CaptureType::Element`; a plain name sets
+/// `CaptureType::Field`. Returns `(CaptureType, var, body)`, or `None` if the syntax
+/// doesn't match.
+fn parse_closure(s: &str) -> Option<(CaptureType, String, String)> {
+    let s = s.trim();
+    let s = s.strip_prefix('|')?;
+    let pipe_end = s.find('|')?;
+    let capture_raw = s[..pipe_end].trim();
+    let (captured, var) = match capture_raw
+        .strip_prefix("each")
+        .filter(|r| r.is_empty() || r.starts_with(char::is_whitespace))
+    {
+        Some(rest) => {
+            let var = rest.trim();
+            if var.is_empty() {
+                return None;
+            }
+            (CaptureType::Element, var.to_string())
+        }
+        None => (CaptureType::Field, capture_raw.to_string()),
+    };
+    let rest = s[pipe_end + 1..].trim();
+    let brace_start = rest.find('{')? + 1;
+    // find the matching closing brace
+    let inner = &rest[brace_start..];
+    let mut depth = 0usize;
+    let brace_end = inner.char_indices().find_map(|(i, c)| match c {
+        '{' => {
+            depth += 1;
+            None
+        }
+        '}' if depth == 0 => Some(i),
+        '}' => {
+            depth -= 1;
+            None
+        }
+        _ => None,
+    })?;
+    let body = inner[..brace_end].trim().to_string();
+    Some((captured, var, body))
 }
 
 #[cfg(test)]
@@ -259,6 +437,7 @@ mod tests {
         assert_eq!(raw.visibility, "public".to_string());
         assert!(!raw.calldata);
         assert!(!raw.solhint_disable);
+        assert!(raw.assert.is_empty());
         let mut expected = vec![FieldArgs::default(); 4];
         expected[1].memory = true;
         assert_eq!(raw.fields, expected);
@@ -276,6 +455,7 @@ mod tests {
         assert_eq!(raw.visibility, "private".to_string());
         assert!(raw.calldata);
         assert!(!raw.solhint_disable);
+        assert!(raw.assert.is_empty());
         let expected = vec![FieldArgs::default(); 4];
         assert_eq!(raw.fields, expected);
     }
@@ -293,6 +473,131 @@ mod tests {
         .unwrap();
         assert!(raw.calldata);
         assert!(raw.solhint_disable);
+    }
+
+    #[test]
+    fn test_assert() {
+        // type-level assert, alone
+        let raw = parse_comment(
+            r#"#[unpack(assert = "|r| { r.version == 1 }")]"#,
+            &vec![(None, false); 1],
+        )
+        .unwrap();
+        assert_eq!(
+            raw.assert,
+            vec![AssertDef {
+                captured: CaptureType::Field,
+                var: "r".to_string(),
+                expr: "r.version == 1".to_string(),
+            }]
+        );
+
+        // assert can appear before other args (no longer required to be last)
+        let raw = parse_comment(
+            r#"#[unpack(assert = "|r| { r.version == 1 }", calldata)]"#,
+            &vec![(None, false); 1],
+        )
+        .unwrap();
+        assert!(raw.calldata);
+        assert_eq!(
+            raw.assert,
+            vec![AssertDef {
+                captured: CaptureType::Field,
+                var: "r".to_string(),
+                expr: "r.version == 1".to_string(),
+            }]
+        );
+
+        // multiple asserts
+        let raw = parse_comment(
+            r#"#[unpack(assert = "|r| { r.version == 1 }", assert = "|r| { r.x > 0 }")]"#,
+            &vec![(None, false); 1],
+        )
+        .unwrap();
+        assert_eq!(
+            raw.assert,
+            vec![
+                AssertDef {
+                    captured: CaptureType::Field,
+                    var: "r".to_string(),
+                    expr: "r.version == 1".to_string(),
+                },
+                AssertDef {
+                    captured: CaptureType::Field,
+                    var: "r".to_string(),
+                    expr: "r.x > 0".to_string(),
+                },
+            ]
+        );
+
+        // body containing a function call with commas and parens (safe inside quotes)
+        let raw = parse_comment(
+            r#"#[unpack(assert = "|r| { isValid(r, 0) }")]"#,
+            &vec![(None, false); 1],
+        )
+        .unwrap();
+        assert_eq!(
+            raw.assert,
+            vec![AssertDef {
+                captured: CaptureType::Field,
+                var: "r".to_string(),
+                expr: "isValid(r, 0)".to_string(),
+            }]
+        );
+
+        // field-level assert
+        let raw = parse_comment(
+            "#[unpack()]",
+            &vec![(
+                Some(r#"#[unpack(assert = "|b| { b.length == 48 }")]"#.to_string()),
+                true,
+            )],
+        )
+        .unwrap();
+        assert_eq!(
+            raw.fields[0].assert,
+            vec![AssertDef {
+                captured: CaptureType::Field,
+                var: "b".to_string(),
+                expr: "b.length == 48".to_string(),
+            }]
+        );
+
+        // element-level assert using `each` keyword
+        let raw = parse_comment(
+            "#[unpack()]",
+            &vec![(
+                Some(r#"#[unpack(assert = "|each x| { x > 0 }")]"#.to_string()),
+                false,
+            )],
+        )
+        .unwrap();
+        assert_eq!(
+            raw.fields[0].assert,
+            vec![AssertDef {
+                captured: CaptureType::Element,
+                var: "x".to_string(),
+                expr: "x > 0".to_string(),
+            }]
+        );
+
+        // `each` prefix on a variable name that starts with "each" is not treated as the keyword
+        let raw = parse_comment(
+            "#[unpack()]",
+            &vec![(
+                Some(r#"#[unpack(assert = "|eachItem| { eachItem > 0 }")]"#.to_string()),
+                false,
+            )],
+        )
+        .unwrap();
+        assert_eq!(
+            raw.fields[0].assert,
+            vec![AssertDef {
+                captured: CaptureType::Field,
+                var: "eachItem".to_string(),
+                expr: "eachItem > 0".to_string(),
+            }]
+        );
     }
 
     #[test]
@@ -327,6 +632,7 @@ mod tests {
                 default: false,
                 memory: false,
                 length: None,
+                assert: vec![],
             }
         );
         assert_eq!(
@@ -336,6 +642,7 @@ mod tests {
                 default: true,
                 memory: true,
                 length: None,
+                assert: vec![],
             }
         );
         assert_eq!(
@@ -345,6 +652,7 @@ mod tests {
                 default: true,
                 memory: false,
                 length: None,
+                assert: vec![],
             }
         );
         assert_eq!(
@@ -354,6 +662,7 @@ mod tests {
                 default: false,
                 memory: true,
                 length: Some(LengthSpec::Type("uint32".to_string())),
+                assert: vec![],
             }
         );
         assert_eq!(
@@ -363,6 +672,7 @@ mod tests {
                 default: false,
                 memory: true,
                 length: Some(LengthSpec::Type("uint64".to_string())),
+                assert: vec![],
             }
         );
         assert_eq!(
@@ -374,6 +684,7 @@ mod tests {
                 length: Some(LengthSpec::Constant(
                     "BLST.BLS_SIGNATURE_LENGTH".to_string()
                 )),
+                assert: vec![],
             }
         );
     }

--- a/icm-macros/src/unpack/methods.rs
+++ b/icm-macros/src/unpack/methods.rs
@@ -4,7 +4,7 @@
 //! named `data` (`bytes calldata data` or `bytes memory data`). Generated code assumes this
 //! name unconditionally — callers must not rename it.
 
-use crate::unpack::hooks::{LengthSpec, UnpackArgs};
+use crate::unpack::hooks::{AssertDef, CaptureType, LengthSpec, UnpackArgs};
 use solar::ast::{ElementaryType, StateMutability};
 use solar::sema::Gcx;
 use solar::sema::hir::{ContractId, Enum, ExprKind, ItemId, Struct, TypeKind};
@@ -127,7 +127,17 @@ pub fn unpack_elementary(
     }
 }
 
-pub fn unpack_enum(enum_def: &Enum, args: UnpackArgs, type_name: &str) -> String {
+pub fn unpack_enum(enum_def: &Enum, args: UnpackArgs, type_name: &str) -> eyre::Result<String> {
+    if args
+        .assert
+        .iter()
+        .any(|a| a.captured == CaptureType::Element)
+    {
+        eyre::bail!(
+            "`each` assert on `{}` is not valid: enums are not container types",
+            enum_def.name,
+        );
+    }
     let fn_name = args
         .name
         .unwrap_or_else(|| format!("unpack{}", enum_def.name));
@@ -137,16 +147,39 @@ pub fn unpack_enum(enum_def: &Enum, args: UnpackArgs, type_name: &str) -> String
         "bytes memory data"
     };
     let vis = vis_prefix(&args.visibility);
-    let body = format!(
-        "function {fn_name}({input}) {vis}pure returns (uint256, {type_name}) {{\n    return (1, {type_name}(uint8(data[0])));\n}}"
-    );
-    if args.solhint_disable {
+    let field_asserts: Vec<_> = args
+        .assert
+        .iter()
+        .filter(|a| a.captured == CaptureType::Field)
+        .collect();
+    let body = if field_asserts.is_empty() {
+        format!(
+            "function {fn_name}({input}) {vis}pure returns (uint256, {type_name}) {{\
+            \n    return (1, {type_name}(uint8(data[0])));\
+            \n}}"
+        )
+    } else {
+        let assert_lines: String = field_asserts
+            .iter()
+            .map(|a| {
+                let expr = substitute_var(&a.expr, &a.var, "result");
+                format!("\n    require({expr});")
+            })
+            .collect();
+        format!(
+            "function {fn_name}({input}) {vis}pure returns (uint256, {type_name}) {{\
+            \n    {type_name} result = {type_name}(uint8(data[0]));{assert_lines}\
+            \n    return (1, result);\
+            \n}}"
+        )
+    };
+    Ok(if args.solhint_disable {
         format!(
             "// solhint-disable no-inline-assembly\n{body}\n// solhint-enable no-inline-assembly"
         )
     } else {
         body
-    }
+    })
 }
 
 pub fn unpack_struct(
@@ -251,11 +284,43 @@ pub fn unpack_struct(
                 output: local_name.clone(),
                 ty: &field.ty.kind,
                 length: field_args.length.clone(),
+                element_asserts: field_args
+                    .assert
+                    .iter()
+                    .filter(|a| a.captured == CaptureType::Element)
+                    .cloned()
+                    .collect(),
             };
             inline_unpack(ctx, args.calldata, target_contract, node)?
         };
         body.push_str(&deserialize_field_code);
         body.push_str(&format!("\nresult.{field_name} = {local_name};"));
+        for assert_def in field_args
+            .assert
+            .iter()
+            .filter(|a| a.captured == CaptureType::Field)
+        {
+            let expr = substitute_var(&assert_def.expr, &assert_def.var, &local_name);
+            body.push_str(&format!("\nrequire({expr});"));
+        }
+    }
+    let mut epilogue = pre_return;
+    for assert_def in &args.assert {
+        match assert_def.captured {
+            CaptureType::Field => {
+                let expr = substitute_var(&assert_def.expr, &assert_def.var, "result");
+                if !epilogue.is_empty() {
+                    epilogue.push('\n');
+                }
+                epilogue.push_str(&format!("require({expr});"));
+            }
+            CaptureType::Element => {
+                eyre::bail!(
+                    "`each` assert on `{}` is not valid at the type level: structs are not container types",
+                    struct_def.name,
+                );
+            }
+        }
     }
     let vis = vis_prefix(&args.visibility);
     let func = format!(
@@ -263,7 +328,7 @@ pub fn unpack_struct(
         \n    {length_tracking}\
         \n    {type_name} memory result;\
         \n    {body}\
-        \n    {pre_return}\
+        \n    {epilogue}\
         \n    return ({bytes_read}, result);\
         \n}}"
     );
@@ -288,6 +353,10 @@ struct UnpackingTreeNode<'a> {
     ty: &'a TypeKind<'a>,
     /// Length/count spec for this node. `None` keeps the default `uint256` prefix.
     length: Option<LengthSpec>,
+    /// `CaptureType::Element` asserts to inject into this node's array loop body,
+    /// substituting the capture variable with the per-element local. Only consulted
+    /// when `ty` is an array; never propagated to the recursive element node.
+    element_asserts: Vec<AssertDef>,
 }
 
 fn inline_unpack(
@@ -298,7 +367,15 @@ fn inline_unpack(
 ) -> eyre::Result<String> {
     Ok(match node.ty {
         TypeKind::Elementary(ty) => {
-            unpack_elementary(&node.output, *ty, calldata, node.length.as_ref())
+            let mut code = unpack_elementary(&node.output, *ty, calldata, node.length.as_ref());
+            if !node.element_asserts.is_empty() {
+                code.push_str(&element_assert_loop(
+                    *ty,
+                    &node.output,
+                    &node.element_asserts,
+                )?);
+            }
+            code
         }
         TypeKind::Array(arr) => {
             let type_name = get_type_name(ctx, &arr.element.kind, target_contract)?;
@@ -308,9 +385,18 @@ fn inline_unpack(
                 output: next_output.clone(),
                 ty: &arr.element.kind,
                 length: None,
+                element_asserts: vec![],
             };
             let output = sanitize_local(&node.output);
             let inner = inline_unpack(ctx, calldata, target_contract, next_node)?;
+            let element_assert_code: String = node
+                .element_asserts
+                .iter()
+                .map(|a| {
+                    let expr = substitute_var(&a.expr, &a.var, &next_output);
+                    format!("\n        require({expr});")
+                })
+                .collect();
             let (read_length, advance_past_count) = match node.length.as_ref() {
                 Some(LengthSpec::Constant(expr)) => {
                     (format!("uint256 length = {expr};"), String::new())
@@ -345,13 +431,20 @@ fn inline_unpack(
                 \n    {output} = new {type_name}[](length);\
                 \n    for (uint256 i = 0; i < length;){{\
                 \n        {inner}\
-                \n        {output}[i] = {next_output};\
+                \n        {output}[i] = {next_output};{element_assert_code}\
                 \n        unchecked {{ ++i;}}\
                 \n    }}\
                 \n}}"
             )
         }
         TypeKind::Custom(item_id) => {
+            if !node.element_asserts.is_empty() {
+                let type_name = custom_type_name(ctx, *item_id);
+                eyre::bail!(
+                    "`each` assert on `{}` requires a container type (array, bytes, string, or bytesN), not `{type_name}`",
+                    node.output,
+                );
+            }
             let type_name = custom_type_name(ctx, *item_id);
             let output = sanitize_local(&node.output);
             let is_enum = matches!(item_id, ItemId::Enum(_));
@@ -646,4 +739,66 @@ fn vis_prefix(visibility: &str) -> String {
     } else {
         format!("{visibility} ")
     }
+}
+
+/// Generates a post-decode element-assertion loop for container elementary types
+/// (`bytes`, `string`, `bytesN`). Each iteration binds `bytes1 _elem` to the current
+/// element and evaluates the assert expressions with the capture variable substituted
+/// by `_elem`. Returns an empty string for non-container types.
+fn element_assert_loop(
+    ty: ElementaryType,
+    output: &str,
+    asserts: &[AssertDef],
+) -> eyre::Result<String> {
+    let (length_expr, access_expr) = match ty {
+        ElementaryType::Bytes => (format!("{output}.length"), format!("{output}[_j]")),
+        ElementaryType::String => (
+            format!("bytes({output}).length"),
+            format!("bytes({output})[_j]"),
+        ),
+        ElementaryType::FixedBytes(s) => (s.bytes().to_string(), format!("{output}[_j]")),
+        _ => eyre::bail!(
+            "`each` assert on `{output}` requires a container type (array, bytes, string, or bytesN), \
+             not `{}`",
+            elementary_type_name(ty),
+        ),
+    };
+    let assert_lines: String = asserts
+        .iter()
+        .map(|a| {
+            let expr = substitute_var(&a.expr, &a.var, "_elem");
+            format!("\n    require({expr});")
+        })
+        .collect();
+    Ok(format!(
+        "\nfor (uint256 _j = 0; _j < {length_expr}; _j++){{\
+        \n    bytes1 _elem = {access_expr};{assert_lines}\
+        \n}}"
+    ))
+}
+
+/// Replaces whole-word occurrences of `var` in `expr` with `replacement`.
+/// A word boundary is any position adjacent to a non-identifier character
+/// (`[^a-zA-Z0-9_]`) or the start/end of the string.
+fn substitute_var(expr: &str, var: &str, replacement: &str) -> String {
+    fn is_ident(c: char) -> bool {
+        c.is_alphanumeric() || c == '_'
+    }
+    let mut result = String::new();
+    let mut remaining = expr;
+    while let Some(pos) = remaining.find(var) {
+        let before = &remaining[..pos];
+        let after = &remaining[pos + var.len()..];
+        let left_ok = before.chars().last().is_none_or(|c| !is_ident(c));
+        let right_ok = after.chars().next().is_none_or(|c| !is_ident(c));
+        result.push_str(before);
+        if left_ok && right_ok {
+            result.push_str(replacement);
+        } else {
+            result.push_str(var);
+        }
+        remaining = after;
+    }
+    result.push_str(remaining);
+    result
 }

--- a/icm-macros/testing/unpack/errors/EachOnCustom.sol
+++ b/icm-macros/testing/unpack/errors/EachOnCustom.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.8.30;
+
+struct Inner {
+    uint256 value;
+}
+
+// #[unpack()]
+struct HasEachOnCustom {
+    // #[unpack(assert = "|each x| { x.value > 0 }")]
+    Inner inner;
+}

--- a/icm-macros/testing/unpack/errors/EachOnEnum.sol
+++ b/icm-macros/testing/unpack/errors/EachOnEnum.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.8.30;
+
+// #[unpack(assert = "|each x| { x > 0 }")]
+enum HasEachAssert {
+    First,
+    Second
+}

--- a/icm-macros/testing/unpack/errors/EachOnNonContainer.sol
+++ b/icm-macros/testing/unpack/errors/EachOnNonContainer.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.8.30;
+
+// #[unpack()]
+struct HasEachOnNonContainer {
+    // #[unpack(assert = "|each x| { x > 0 }")]
+    uint256 value;
+}

--- a/icm-macros/testing/unpack/errors/EachOnStruct.sol
+++ b/icm-macros/testing/unpack/errors/EachOnStruct.sol
@@ -1,0 +1,6 @@
+pragma solidity ^0.8.30;
+
+// #[unpack(assert = "|each x| { x > 0 }")]
+struct HasEachAssert {
+    uint256 value;
+}

--- a/icm-macros/testing/unpack/expected/PostConditions.sol
+++ b/icm-macros/testing/unpack/expected/PostConditions.sol
@@ -1,0 +1,114 @@
+pragma solidity ^0.8.30;
+
+library PackMethods {
+    // #[unpack(
+    //    calldata,
+    //    assert = "|t| { t.Bytes.length == bytes(t.String).length }",
+    //  )]
+    struct Struct {
+        bytes Bytes;
+        string String;
+        // #[unpack(
+        //    assert = "|inner| { inner.length > 0 }",
+        //    assert = "|each v| { v > 0 }",
+        //  )]
+        Inner[] inner;
+        // #[unpack(
+        //    assert = "|m| { m.flag }",
+        //    method = "parseMethod",
+        //  )]
+        Method method;
+    }
+
+    // #[unpack()]
+    struct Inner {
+        //#[unpack(assert = "|v| { v < 10 }")]
+        uint256 value;
+    }
+
+    struct Method {
+        bool flag;
+    }
+
+    function parseMethod(bytes calldata data) public pure returns (uint256, Method memory) {
+        Method memory res;
+        if (data[0]) {
+            res.flag = true;
+        } else {
+            res.flag = false;
+        }
+        return (1, res);
+    }
+
+    function unpackStruct(bytes calldata data) public pure returns (uint256, Struct memory) {
+        uint256 _initial_length = data.length;
+        Struct memory result;
+
+        bytes memory Bytes;
+        {
+            uint256 length = uint256(bytes32(data[0:32]));
+            Bytes = bytes(data[32:length + 32]);
+            data = data[32 + length:];
+        }
+        result.Bytes = Bytes;
+        string memory String;
+        {
+            uint256 length = uint256(bytes32(data[0:32]));
+            String = string(data[32:length + 32]);
+            data = data[32 + length:];
+        }
+        result.String = String;
+        Inner[] memory inner;
+        {
+            uint256 length = uint256(bytes32(data[0:32]));
+            data = data[32:];
+            inner = new Inner[](length);
+            for (uint256 i = 0; i < length;) {
+                Inner memory inner_1;
+                {
+                    uint256 read;
+                    (read, inner_1) = unpackInner(data);
+                    data = data[read:];
+                }
+                inner[i] = inner_1;
+                require(inner_1 > 0);
+                unchecked {
+                    ++i;
+                }
+            }
+        }
+        result.inner = inner;
+        require(inner.length > 0);
+        Method memory method;
+        {
+            uint256 read;
+            (read, method) = parseMethod(data);
+            data = data[read:];
+        }
+        result.method = method;
+        require(method.flag);
+        require(result.Bytes.length == bytes(result.String).length);
+        return (_initial_length - data.length, result);
+    }
+
+    function unpackInner(bytes memory data) public pure returns (uint256, Inner memory) {
+        uint256 _initial_length;
+        assembly { _initial_length := mload(data) }
+        Inner memory result;
+
+        uint256 value;
+        assembly {
+            value := shr(0, mload(add(data, 32)))
+        }
+        assembly {
+            let _data_new_len := sub(mload(data), 32)
+            data := add(data, 32)
+            mstore(data, _data_new_len)
+        }
+        result.value = value;
+        require(value < 10);
+        uint256 _final_length;
+        assembly { _final_length := mload(data) }
+        return (_initial_length - _final_length, result);
+    }
+}

--- a/icm-macros/testing/unpack/source/PostConditions.sol
+++ b/icm-macros/testing/unpack/source/PostConditions.sol
@@ -1,0 +1,43 @@
+pragma solidity ^0.8.30;
+
+library PackMethods {
+
+    // #[unpack(
+    //    calldata,
+    //    assert = "|t| { t.Bytes.length == bytes(t.String).length }",
+    //  )]
+    struct Struct {
+        bytes Bytes;
+        string String;
+        // #[unpack(
+        //    assert = "|inner| { inner.length > 0 }",
+        //    assert = "|each v| { v > 0 }",
+        //  )]
+        Inner[] inner;
+        // #[unpack(
+        //    assert = "|m| { m.flag }",
+        //    method = "parseMethod",
+        //  )]
+        Method method;
+    }
+
+    // #[unpack()]
+    struct Inner {
+        //#[unpack(assert = "|v| { v < 10 }")]
+        uint256 value;
+    }
+
+    struct Method {
+        bool flag;
+    }
+
+    function parseMethod(bytes calldata data) pure public returns (uint256, Method memory) {
+        Method memory res;
+        if (data[0]) {
+            res.flag = true;
+        } else {
+            res.flag = false;
+        }
+        return (1, res);
+    }
+}


### PR DESCRIPTION
## Why this should be merged
Closes #1334

Adds assert post-conditions to the #[unpack(...)] macro. Three forms are supported:                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                      
  - Type-level (assert = "|var| { expr }" on the struct annotation): emits require(expr) just before the function returns, with var substituted by result.                                                                                                                                                                                                                                                            
  - Field-level (assert = "|var| { expr }" on a field): emits require(expr) immediately after the field is assigned to result, with var substituted by the field's local variable.                                                                                                                                                                                                                                    
  - Element-level (assert = "|each var| { expr }" on a field): for array fields, emits require(expr) inside the decode loop per element; for bytes/string/bytesN fields, emits a post-decode byte iteration loop.                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                      
  Multiple assert keys may appear on a single annotation. The closure value is a quoted string so commas and = signs inside the expression are not misinterpreted as argument separators. each is rejected at the type level and on non-container fields with a descriptive error.                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                                                      
  The multi-line comment parser was also fixed: reforge::get_comment concatenates comment lines without newlines, so strip_comment_prefixes now splits on embedded // occurrences (outside quoted strings) in addition to \n.                                                             
## How this works

## How this was tested

## How is this documented