### PR TITLE
Increase timeout on connecting to a quorum of validators

### DIFF
--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -263,6 +263,7 @@ func main() {
 			relayerMetricsRegistry,
 		),
 		clients.NewCanonicalValidatorClient(cfg.PChainAPI),
+		2*utils.DefaultAppRequestTimeout,
 	)
 	if err != nil {
 		logger.Fatal("Failed to create signature aggregator", zap.Error(err))

--- a/signature-aggregator/aggregator/aggregator.go
+++ b/signature-aggregator/aggregator/aggregator.go
@@ -40,12 +40,9 @@ import (
 type blsSignatureBuf [bls.SignatureLen]byte
 
 const (
-	// Maximum amount of time to spend waiting (in addition to network round trip time per attempt)
-	// during relayer signature query routine
-	signatureRequestTimeout = 2 * utils.DefaultAppRequestTimeout
 	// Maximum amount of time to spend waiting for a connection to a quorum of validators for
 	// a given subnetID
-	connectToValidatorsTimeout = 5 * time.Second
+	connectToValidatorsTimeout = 30 * time.Second
 
 	// The minimum balance that an L1 validator must maintain in order to participate
 	// in the aggregate signature.
@@ -63,13 +60,14 @@ var (
 )
 
 type SignatureAggregator struct {
-	network                *peers.AppRequestNetwork
-	messageCreator         message.Creator
-	currentRequestID       atomic.Uint32
-	metrics                *metrics.SignatureAggregatorMetrics
-	signatureCache         *SignatureCache
-	validatorClient        clients.CanonicalValidatorState
-	underfundedL1NodeCache *cache.TTLCache[ids.ID, set.Set[ids.NodeID]]
+	network                 *peers.AppRequestNetwork
+	messageCreator          message.Creator
+	currentRequestID        atomic.Uint32
+	metrics                 *metrics.SignatureAggregatorMetrics
+	signatureCache          *SignatureCache
+	validatorClient         clients.CanonicalValidatorState
+	underfundedL1NodeCache  *cache.TTLCache[ids.ID, set.Set[ids.NodeID]]
+	signatureRequestTimeout time.Duration
 
 	subnetMapsLock sync.Mutex
 
@@ -84,6 +82,7 @@ func NewSignatureAggregator(
 	signatureCacheSize uint64,
 	metrics *metrics.SignatureAggregatorMetrics,
 	validatorClient clients.CanonicalValidatorState,
+	signatureRequestTimeout time.Duration,
 ) (*SignatureAggregator, error) {
 	signatureCache, err := NewSignatureCache(signatureCacheSize)
 	if err != nil {
@@ -99,6 +98,7 @@ func NewSignatureAggregator(
 		messageCreator:          messageCreator,
 		validatorClient:         validatorClient,
 		underfundedL1NodeCache:  cache.NewTTLCache[ids.ID, set.Set[ids.NodeID]](l1ValidatorBalanceTTL),
+		signatureRequestTimeout: signatureRequestTimeout,
 	}
 	// invariant: requestIDs for AppRequests must be odd numbered
 	sa.currentRequestID.Store(rand.Uint32() | 1)
@@ -509,7 +509,7 @@ func (s *SignatureAggregator) collectSignaturesWithRetries(
 		)
 	}
 
-	err := utils.WithRetriesTimeout(operation, notify, signatureRequestTimeout)
+	err := utils.WithRetriesTimeout(operation, notify, s.signatureRequestTimeout)
 	if err != nil {
 		logger.Warn(
 			"Failed to collect a threshold of signatures",

--- a/signature-aggregator/aggregator/aggregator_test.go
+++ b/signature-aggregator/aggregator/aggregator_test.go
@@ -33,7 +33,22 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func instantiateAggregator(t *testing.T) (
+const defaultSignatureRequestTimeout = 20 * time.Second
+
+func instantiateDefaultAggregator(t *testing.T) (
+	*SignatureAggregator,
+	*peers.AppRequestNetwork,
+	*peers.RelayerExternalHandler,
+	*avago_mocks.MockNetwork,
+	*client_mocks.MockCanonicalValidatorState,
+) {
+	return instantiateAggregator(t, defaultSignatureRequestTimeout)
+}
+
+func instantiateAggregator(
+	t *testing.T,
+	signatureRequestTimeout time.Duration,
+) (
 	*SignatureAggregator,
 	*peers.AppRequestNetwork,
 	*peers.RelayerExternalHandler, // handler for test access
@@ -82,6 +97,7 @@ func instantiateAggregator(t *testing.T) (
 		1024,
 		testSigAggMetrics,
 		mockValidatorClient,
+		signatureRequestTimeout,
 	)
 	require.NoError(t, err)
 
@@ -168,7 +184,7 @@ func TestCreateSignedMessageFailsInvalidQuorumPercentage(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			aggregator, _, _, _, _ := instantiateAggregator(t)
+			aggregator, _, _, _, _ := instantiateDefaultAggregator(t)
 			signedMsg, err := aggregator.CreateSignedMessage(
 				t.Context(),
 				logging.NoLog{},
@@ -186,7 +202,7 @@ func TestCreateSignedMessageFailsInvalidQuorumPercentage(t *testing.T) {
 }
 
 func TestCreateSignedMessageFailsWithNoValidators(t *testing.T) {
-	aggregator, _, _, mockNetwork, mockValidatorClient := instantiateAggregator(t)
+	aggregator, _, _, mockNetwork, mockValidatorClient := instantiateDefaultAggregator(t)
 	msg, err := warp.NewUnsignedMessage(0, ids.Empty, []byte{})
 	require.NoError(t, err)
 	mockValidatorClient.EXPECT().GetSubnetID(gomock.Any(), ids.Empty).Return(ids.Empty, nil).AnyTimes()
@@ -214,7 +230,7 @@ func TestCreateSignedMessageFailsWithNoValidators(t *testing.T) {
 }
 
 func TestCreateSignedMessageFailsWithoutSufficientConnectedStake(t *testing.T) {
-	aggregator, _, _, mockNetwork, mockValidatorClient := instantiateAggregator(t)
+	aggregator, _, _, mockNetwork, mockValidatorClient := instantiateDefaultAggregator(t)
 	msg, err := warp.NewUnsignedMessage(0, ids.Empty, []byte{})
 	require.NoError(t, err)
 	mockValidatorClient.EXPECT().GetSubnetID(gomock.Any(), ids.Empty).Return(ids.Empty, nil)
@@ -270,7 +286,7 @@ func makeAppRequests(
 }
 
 func TestCreateSignedMessageRetriesAndFailsWithoutP2PResponses(t *testing.T) {
-	aggregator, _, _, mockNetwork, mockValidatorClient := instantiateAggregator(t)
+	aggregator, _, _, mockNetwork, mockValidatorClient := instantiateAggregator(t, 100*time.Millisecond)
 
 	var (
 		connectedValidators, _ = makeConnectedValidators(2)
@@ -373,7 +389,7 @@ func TestCreateSignedMessageSucceeds(t *testing.T) {
 
 			// prime the aggregator:
 
-			aggregator, _, handler, mockNetwork, mockValidatorClient := instantiateAggregator(t)
+			aggregator, _, handler, mockNetwork, mockValidatorClient := instantiateDefaultAggregator(t)
 
 			subnetID := ids.GenerateTestID()
 			mockValidatorClient.EXPECT().GetSubnetID(gomock.Any(), chainID).Return(
@@ -505,7 +521,7 @@ func TestCreateSignedMessageSucceeds(t *testing.T) {
 }
 
 func TestUnmarshalResponse(t *testing.T) {
-	aggregator, _, _, _, _ := instantiateAggregator(t)
+	aggregator, _, _, _, _ := instantiateDefaultAggregator(t)
 
 	emptySignatureResponse, err := proto.Marshal(&sdk.SignatureResponse{Signature: []byte{}})
 	require.NoError(t, err)
@@ -758,7 +774,7 @@ func TestGetExcludedValidators(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			aggregator, _, _, _, mockValidatorClient := instantiateAggregator(t)
+			aggregator, _, _, _, mockValidatorClient := instantiateDefaultAggregator(t)
 			ctx := t.Context()
 			log := logging.NoLog{}
 			signingSubnet := ids.GenerateTestID()
@@ -823,7 +839,7 @@ func TestValidateQuorumPercentages(t *testing.T) {
 }
 
 func TestSelectSigningSubnet(t *testing.T) {
-	aggregator, _, _, _, _ := instantiateAggregator(t)
+	aggregator, _, _, _, _ := instantiateDefaultAggregator(t)
 	ctx := t.Context()
 	log := logging.NoLog{}
 	chainID := ids.GenerateTestID()
@@ -849,7 +865,7 @@ func TestSelectSigningSubnet(t *testing.T) {
 }
 
 func TestPopulateSignatureMapFromCache(t *testing.T) {
-	aggregator, _, _, _, _ := instantiateAggregator(t)
+	aggregator, _, _, _, _ := instantiateDefaultAggregator(t)
 	connectedValidators, signers := makeConnectedValidators(2)
 	msg, err := warp.NewUnsignedMessage(0, ids.GenerateTestID(), []byte("test"))
 	require.NoError(t, err)

--- a/signature-aggregator/main/main.go
+++ b/signature-aggregator/main/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ava-labs/icm-services/signature-aggregator/config"
 	"github.com/ava-labs/icm-services/signature-aggregator/healthcheck"
 	"github.com/ava-labs/icm-services/signature-aggregator/metrics"
+	"github.com/ava-labs/icm-services/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -166,6 +167,7 @@ func main() {
 		cfg.SignatureCacheSize,
 		metricsInstance,
 		clients.NewCanonicalValidatorClient(cfg.PChainAPI),
+		2*utils.DefaultAppRequestTimeout,
 	)
 	if err != nil {
 		logger.Fatal("Failed to create signature aggregator", zap.Error(err))


### PR DESCRIPTION
## Why this should be merged
Services E2E tests are currently flaky - sometimes we will timeout connecting to a quorum of validators. I've increased the timeout from 5s to 30s, but this also required a change to one of the unit tests, so we now pass in one of the timeouts to the constructor for the sigagg so that we can use a lower value in the unit tests.

## How this works

## How this was tested

## How is this documented