### PR TITLE
Small cleanups

### DIFF
--- a/database/relayer_id.go
+++ b/database/relayer_id.go
@@ -108,7 +108,7 @@ func GetSourceBlockchainRelayerIDs(sourceBlockchain *config.SourceBlockchain) []
 	srcAddresses := sourceBlockchain.GetAllowedOriginSenderAddresses()
 	// If no addresses are provided, use the zero address to construct the relayer ID
 	if len(srcAddresses) == 0 {
-		srcAddresses = append(srcAddresses, AllAllowedAddress)
+		srcAddresses = []common.Address{AllAllowedAddress}
 	}
 	for _, protocol := range sourceBlockchain.Protocols() {
 		for _, srcAddress := range srcAddresses {
@@ -116,7 +116,7 @@ func GetSourceBlockchainRelayerIDs(sourceBlockchain *config.SourceBlockchain) []
 				dstAddresses := dst.GetAddresses()
 				// If no addresses are provided, use the zero address to construct the relayer ID
 				if len(dstAddresses) == 0 {
-					dstAddresses = append(dstAddresses, AllAllowedAddress)
+					dstAddresses = []common.Address{AllAllowedAddress}
 				}
 				for _, dstAddress := range dstAddresses {
 					ids = append(ids, NewRelayerID(

--- a/messages/off-chain-registry/message_handler.go
+++ b/messages/off-chain-registry/message_handler.go
@@ -79,17 +79,12 @@ func (f *factory) NewMessageHandler(
 	}, nil
 }
 
-func (f *factory) GetMessageRoutingInfo(unsignedMessage *warp.UnsignedMessage) (
-	messages.MessageRoutingInfo,
-	error,
-) {
-	addressedPayload, err := warpPayload.ParseAddressedCall(unsignedMessage.Payload)
-	if err != nil {
-		return messages.MessageRoutingInfo{}, fmt.Errorf("failed parsing addressed payload: %w", err)
-	}
+func (f *factory) GetMessageRoutingInfo(
+	unsignedMessage *warp.UnsignedMessage,
+) (messages.MessageRoutingInfo, error) {
 	return messages.MessageRoutingInfo{
 			SourceChainID:      unsignedMessage.SourceChainID,
-			SenderAddress:      common.BytesToAddress(addressedPayload.SourceAddress),
+			SenderAddress:      OffChainRegistrySourceAddress, // Off-chain registry messages have a zero address as the sender
 			DestinationChainID: unsignedMessage.SourceChainID,
 			DestinationAddress: f.registryAddress,
 		},

--- a/relayer/application_relayer.go
+++ b/relayer/application_relayer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ava-labs/icm-services/database"
 	"github.com/ava-labs/icm-services/messages"
 	"github.com/ava-labs/icm-services/peers"
+	"github.com/ava-labs/icm-services/relayer/checkpoint"
 	"github.com/ava-labs/icm-services/relayer/config"
 	"github.com/ava-labs/icm-services/signature-aggregator/aggregator"
 	"github.com/ava-labs/icm-services/utils"
@@ -33,17 +34,6 @@ const (
 	defaultQuorumPercentageBuffer = uint64(3)
 )
 
-// CheckpointManager stores committed heights in the database
-type CheckpointManager interface {
-	// Run starts a go routine that periodically stores the last committed height in the Database
-	Run()
-	// StageCommittedHeight queues a height to be written to the database.
-	// Heights are committed in sequence, so if height is not exactly one
-	// greater than the current committedHeight, it is instead cached in memory
-	// to potentially be committed later.
-	StageCommittedHeight(height uint64)
-}
-
 // ApplicationRelayers define a Warp message route from a specific source address on a specific source blockchain
 // to a specific destination address on a specific destination blockchain. This routing information is
 // encapsulated in [relayerID], which also represents the database key for an ApplicationRelayer.
@@ -55,7 +45,7 @@ type ApplicationRelayer struct {
 	destinationClient       vms.DestinationClient
 	relayerID               database.RelayerID
 	warpConfig              config.WarpConfig
-	checkpointManager       CheckpointManager
+	checkpointManager       *checkpoint.CheckpointManager
 	signatureAggregator     *aggregator.SignatureAggregator
 	processMessageSemaphore chan struct{}
 }
@@ -67,7 +57,7 @@ func NewApplicationRelayer(
 	relayerID database.RelayerID,
 	destinationClient vms.DestinationClient,
 	sourceBlockchain *config.SourceBlockchain,
-	checkpointManager CheckpointManager,
+	checkpointManager *checkpoint.CheckpointManager,
 	cfg *config.Config,
 	signatureAggregator *aggregator.SignatureAggregator,
 	processMessageSemaphore chan struct{},

--- a/relayer/main/main.go
+++ b/relayer/main/main.go
@@ -568,7 +568,7 @@ func createApplicationRelayersForSourceChain(
 	}
 
 	for _, relayerID := range database.GetSourceBlockchainRelayerIDs(sourceBlockchain) {
-		logger = logger.With(
+		log := logger.With(
 			zap.Stringer("relayerID", relayerID.ID),
 			zap.Stringer("destinationBlockchainID", relayerID.DestinationBlockchainID),
 			zap.Stringer("originSenderAddress", relayerID.OriginSenderAddress),
@@ -578,14 +578,14 @@ func createApplicationRelayersForSourceChain(
 		if cfg.ProcessMissedBlocks {
 			var err error
 			height, err = database.CalculateStartingBlockHeight(
-				logger,
+				log,
 				db,
 				relayerID,
 				sourceBlockchain.ProcessHistoricalBlocksFromHeight,
 				currentHeight,
 			)
 			if err != nil {
-				logger.Error("Failed to calculate starting block height", zap.Error(err))
+				log.Error("Failed to calculate starting block height", zap.Error(err))
 				return nil, 0, err
 			}
 
@@ -596,7 +596,7 @@ func createApplicationRelayersForSourceChain(
 		}
 
 		checkpointManager, err := checkpoint.NewCheckpointManager(
-			logger,
+			log,
 			checkpointMetrics,
 			db,
 			ticker.Subscribe(),
@@ -604,12 +604,12 @@ func createApplicationRelayersForSourceChain(
 			height,
 		)
 		if err != nil {
-			logger.Error("Failed to create checkpoint manager", zap.Error(err))
+			log.Error("Failed to create checkpoint manager", zap.Error(err))
 			return nil, 0, err
 		}
 
 		applicationRelayer, err := relayer.NewApplicationRelayer(
-			logger,
+			log,
 			metrics,
 			network,
 			relayerID,
@@ -621,12 +621,12 @@ func createApplicationRelayersForSourceChain(
 			processMessageSemaphore,
 		)
 		if err != nil {
-			logger.Error("Failed to create application relayer", zap.Error(err))
+			log.Error("Failed to create application relayer", zap.Error(err))
 			return nil, 0, err
 		}
 		applicationRelayers[relayerID.ID] = applicationRelayer
 
-		logger.Info("Created application relayer")
+		log.Info("Created application relayer")
 	}
 	return applicationRelayers, minHeight, nil
 }


### PR DESCRIPTION
## Why this should be merged
Removes unnecessary `CheckpointManager` interface.

I was previously under the impressing that a k/v pair added with `logger.With()` would override a previous value with the same key - this is not true. So there are a couple places (especially in loops) where I've made sure to create a newly scoped logger instead of looping over one instance and adding to it.

Uses `[]common.Address{AllAllowedAddress}` instead of appending to an empty slice for clarity.

## How this works

## How this was tested

## How is this documented