### PR TITLE
fix unused parameter and callsite

### DIFF
--- a/signature-aggregator/aggregator/aggregator.go
+++ b/signature-aggregator/aggregator/aggregator.go
@@ -693,7 +693,7 @@ func (s *SignatureAggregator) CreateSignedMessage(
 		))
 	}
 
-	reqBytes, err := s.marshalRequest(unsignedMessage, justification, sourceSubnet)
+	reqBytes, err := s.marshalRequest(unsignedMessage, justification)
 	if err != nil {
 		msg := "Failed to marshal request bytes"
 		log.Error(msg, zap.Error(err))
@@ -1025,7 +1025,6 @@ func (s *SignatureAggregator) aggregateSignatures(
 func (s *SignatureAggregator) marshalRequest(
 	unsignedMessage *avalancheWarp.UnsignedMessage,
 	justification []byte,
-	sourceSubnet ids.ID,
 ) ([]byte, error) {
 	messageBytes, err := proto.Marshal(
 		&sdk.SignatureRequest{


### PR DESCRIPTION
## Why this should be merged
Contributes to general code cleanliness. Even though the Go compiler catches unused variables, enforcing that in function parameters would be difficult and incorrect. I just caught an unused variable as I was looking around.

## How this works
There was one callsite for `marshalRequest`, so after removing it from the function parameters, I removed it from there too.

## How this was tested

## How is this documented
There were no comments or documentation, it's a small helper function.