### PR TITLE
remove darwin releases from icm-services goreleaser actions

### DIFF
--- a/relayer/.goreleaser.yml
+++ b/relayer/.goreleaser.yml
@@ -10,10 +10,9 @@ builds:
     flags:
       - -v
     # windows is ignored by default, as the `goos` field by default only
-    # contains linux and darwin
+    # contains linux
     goos:
       - linux
-      - darwin
     goarch:
       - amd64
       - arm64
@@ -26,16 +25,6 @@ builds:
         goarm64: v8.0
         env:
           - CC=aarch64-linux-gnu-gcc
-      - goos: darwin
-        goarch: arm64
-        goarm64: v8.0
-        env:
-          - CC=oa64-clang
-      - goos: darwin
-        goarch: amd64
-        goamd64: v1
-        env:
-          - CC=o64-clang
 dockers:
   - image_templates:
     - 'avaplatform/icm-relayer:{{ .Tag }}-amd64'

--- a/signature-aggregator/.goreleaser.yml
+++ b/signature-aggregator/.goreleaser.yml
@@ -10,10 +10,9 @@ builds:
     flags:
       - -v
     # windows is ignored by default, as the `goos` field by default only
-    # contains linux and darwin
+    # contains linux
     goos:
       - linux
-      - darwin
     goarch:
       - amd64
       - arm64
@@ -26,16 +25,6 @@ builds:
         goarm64: v8.0
         env:
           - CC=aarch64-linux-gnu-gcc
-      - goos: darwin
-        goarch: arm64
-        goarm64: v8.0
-        env:
-          - CC=oa64-clang
-      - goos: darwin
-        goarch: amd64
-        goamd64: v1
-        env:
-          - CC=o64-clang
 dockers:
   - image_templates:
     - 'avaplatform/signature-aggregator:{{ .Tag }}-amd64'


### PR DESCRIPTION
## Why this should be merged

## How this works

## How this was tested

## How is this documented