### PR TITLE
Only skip bloom filter check on the primary network

### DIFF
--- a/relayer/listener.go
+++ b/relayer/listener.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/icm-services/relayer/config"
 	"github.com/ava-labs/icm-services/types"
@@ -137,6 +138,7 @@ func newListener(
 	sub := evm.NewSubscriber(
 		logger,
 		blockchainID,
+		sourceBlockchain.GetSubnetID() == constants.PrimaryNetworkID,
 		ethWSClient,
 		ethRPCClient,
 		errChan,

--- a/types/types.go
+++ b/types/types.go
@@ -49,33 +49,48 @@ func NewICMBlockInfo(
 	header *types.Header,
 	ethClient ethereum.LogFilterer,
 	topics [][]common.Hash,
+	isPrimaryNetwork bool,
 ) (*ICMBlockInfo, error) {
-	var logs []types.Log
-	cctx, cancel := context.WithTimeout(context.Background(), utils.DefaultRPCTimeout)
-	defer cancel()
-	operation := func() (err error) {
-		logs, err = ethClient.FilterLogs(cctx, ethereum.FilterQuery{
-			Topics:    topics,
-			FromBlock: header.Number,
-			ToBlock:   header.Number,
-		})
-		return err
-	}
-	notify := func(err error, duration time.Duration) {
-		logger.Info(
-			"getting ICM block from logs failed, retrying...",
-			zap.Duration("retryIn", duration),
-			zap.Error(err),
-		)
-	}
+	var (
+		logs []types.Log
+		err  error
+	)
+	// Only fetch logs when the block's bloom filter indicates that one of the event
+	// topics we filter for (topics[0]) is present. A bloom match may be a false
+	// positive; the FilterLogs call below performs the precise filtering.
+	//
+	// On the primary network (C-Chain) the header bloom filter cannot be relied on
+	// as a shortcut: it summarises a settled predecessor range rather than the
+	// block's own receipts, so the shortcut would silently miss events. Bypass the
+	// bloom check there and always fetch the logs.
+	if isPrimaryNetwork || bloomContainsAnyEventTopic(header.Bloom, topics) {
+		cctx, cancel := context.WithTimeout(context.Background(), utils.DefaultRPCTimeout)
+		defer cancel()
+		operation := func() (err error) {
+			logs, err = ethClient.FilterLogs(cctx, ethereum.FilterQuery{
+				Topics:    topics,
+				FromBlock: header.Number,
+				ToBlock:   header.Number,
+			})
+			return err
+		}
+		notify := func(err error, duration time.Duration) {
+			logger.Info(
+				"getting ICM block from logs failed, retrying...",
+				zap.Duration("retryIn", duration),
+				zap.Error(err),
+			)
+		}
 
-	// We increase the timeout here to 30 seconds reducing the chance of hitting a race condition
-	// where the block header is received via websocket subscription before the block's
-	// logs are available via RPC. This is a known behavior in EVM nodes due to
-	// asynchronous log/index processing after a block becomes canonical.
-	timeout := utils.DefaultRPCTimeout * 6
-	if err := utils.WithRetriesTimeout(operation, notify, timeout); err != nil {
-		return nil, fmt.Errorf("failed to get logs for block: %w", err)
+		// We increase the timeout here to 30 seconds reducing the chance of hitting a race condition
+		// where the block header is received via websocket subscription before the block's
+		// logs are available via RPC. This is a known behavior in EVM nodes due to
+		// asynchronous log/index processing after a block becomes canonical.
+		timeout := utils.DefaultRPCTimeout * 6
+		err = utils.WithRetriesTimeout(operation, notify, timeout)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get logs for block: %w", err)
+		}
 	}
 
 	return &ICMBlockInfo{
@@ -83,6 +98,23 @@ func NewICMBlockInfo(
 		Logs:        logs,
 		IsCatchup:   false,
 	}, nil
+}
+
+// bloomContainsAnyEventTopic reports whether the block's bloom filter indicates the presence of at
+// least one of the event-signature topics being filtered for (the first topic position, topics[0]).
+// If no event-signature topics are provided, it conservatively returns true so that logs are still
+// fetched. A positive result may be a false positive due to the probabilistic nature of bloom
+// filters; callers must perform precise filtering afterwards.
+func bloomContainsAnyEventTopic(bloom types.Bloom, topics [][]common.Hash) bool {
+	if len(topics) == 0 || len(topics[0]) == 0 {
+		return true
+	}
+	for _, eventTopic := range topics[0] {
+		if bloom.Test(eventTopic[:]) {
+			return true
+		}
+	}
+	return false
 }
 
 // Extract the Warp message information from the raw log

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -35,13 +35,14 @@ type SubscriberWSClient interface {
 }
 
 type Subscriber struct {
-	wsClient     SubscriberWSClient
-	rpcClient    SubscriberRPCClient
-	blockchainID ids.ID
-	topics       [][]common.Hash
-	headers      chan *types.Header
-	icmBlocks    chan *relayerTypes.ICMBlockInfo
-	sub          ethereum.Subscription
+	wsClient         SubscriberWSClient
+	rpcClient        SubscriberRPCClient
+	blockchainID     ids.ID
+	isPrimaryNetwork bool
+	topics           [][]common.Hash
+	headers          chan *types.Header
+	icmBlocks        chan *relayerTypes.ICMBlockInfo
+	sub              ethereum.Subscription
 
 	errChan chan error
 
@@ -52,20 +53,22 @@ type Subscriber struct {
 func NewSubscriber(
 	logger logging.Logger,
 	blockchainID ids.ID,
+	isPrimaryNetwork bool,
 	wsClient SubscriberWSClient,
 	rpcClient SubscriberRPCClient,
 	errChan chan error,
 	topics [][]common.Hash,
 ) *Subscriber {
 	subscriber := &Subscriber{
-		blockchainID: blockchainID,
-		topics:       topics,
-		wsClient:     wsClient,
-		rpcClient:    rpcClient,
-		logger:       logger,
-		icmBlocks:    make(chan *relayerTypes.ICMBlockInfo, maxClientSubscriptionBuffer),
-		headers:      make(chan *types.Header, maxClientSubscriptionBuffer),
-		errChan:      errChan,
+		blockchainID:     blockchainID,
+		isPrimaryNetwork: isPrimaryNetwork,
+		topics:           topics,
+		wsClient:         wsClient,
+		rpcClient:        rpcClient,
+		logger:           logger,
+		icmBlocks:        make(chan *relayerTypes.ICMBlockInfo, maxClientSubscriptionBuffer),
+		headers:          make(chan *types.Header, maxClientSubscriptionBuffer),
+		errChan:          errChan,
 	}
 	go subscriber.blocksInfoFromHeaders()
 	return subscriber
@@ -198,7 +201,7 @@ func (s *Subscriber) subscribe(retryTimeout time.Duration) error {
 // and writes them to the blocks channel consumed by the listener
 func (s *Subscriber) blocksInfoFromHeaders() {
 	for header := range s.headers {
-		block, err := relayerTypes.NewICMBlockInfo(s.logger, header, s.rpcClient, s.topics)
+		block, err := relayerTypes.NewICMBlockInfo(s.logger, header, s.rpcClient, s.topics, s.isPrimaryNetwork)
 		if err != nil {
 			s.errChan <- fmt.Errorf("creating warp block info: %w", err)
 			return

--- a/vms/evm/subscriber_test.go
+++ b/vms/evm/subscriber_test.go
@@ -67,6 +67,7 @@ func makeSubscriberWithMockEthClient(t *testing.T, errChan chan error) (*Subscri
 	subscriber := NewSubscriber(
 		logging.NoLog{},
 		blockchainID,
+		false,
 		stubRPCClient,
 		stubRPCClient,
 		errChan,


### PR DESCRIPTION
## Why this should be merged
Partially reverts the changes from https://github.com/ava-labs/icm-services/pull/1421. We'll only skip the bloom filter check for the primary network for now. We'll need to revisit how to properly do this for all networks when SAE becomes enabled on L1s.

## How this works

## How this was tested

## How is this documented