### PR TITLE
add workflow

### DIFF
--- a/.github/workflows/relayer_fuji_load_test.yml
+++ b/.github/workflows/relayer_fuji_load_test.yml
@@ -1,0 +1,149 @@
+# Manually-triggered load test of the relayer against Fuji (C-Chain / Echo / Dispatch).
+#
+# What it does:
+#   1. Builds the relayer from source at the dispatched ref.
+#   2. Checks out ava-labs/icm-relayer-load-simulator at the `load-sim-ref` input
+#      (private repo; LOAD_SIM_CHECKOUT_TOKEN secret must grant read access).
+#   3. Renders configs from that repo's config/fuji/*.template.json: RPC tokens
+#      via envsubst, load wallets via jq, then filters the relayer config down to
+#      the source/destination pair for this run.
+#   4. Runs the simulator, which starts the relayer, sends messages via its
+#      Sender/Receiver contracts on Fuji, and tracks deliveries in relayer logs.
+#   5. Fails if any sent message is not delivered. Verdict and latency table go
+#      to the step summary; raw CSVs and logs are uploaded as an artifact.
+#
+# Config schema, secret descriptions, and contract deployment steps live with
+# the simulator: icm-relayer-load-simulator/config/fuji/README.md.
+# Wallets and funding are shared state, so concurrent runs are queued.
+
+name: Relayer Fuji Load Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      source:
+        description: "Source chain (where messages are sent from)"
+        type: choice
+        options: [c-chain, echo, dispatch]
+        default: c-chain
+      destination:
+        description: "Destination chain (where messages are delivered)"
+        type: choice
+        options: [c-chain, echo, dispatch]
+        default: echo
+      count:
+        description: "Total number of messages to send"
+        type: number
+        default: 20
+      rate:
+        description: "Messages to send per second"
+        type: number
+        default: 2
+      timeout:
+        description: "Seconds to wait for all deliveries before failing"
+        type: number
+        default: 600
+      load-sim-ref:
+        description: "Branch/tag/SHA of icm-relayer-load-simulator to use"
+        type: string
+        default: main
+
+# The load wallets and relayer EOA are shared resources: two concurrent runs
+# would collide on nonces. Queue runs instead.
+concurrency:
+  group: relayer-fuji-load-test
+  cancel-in-progress: false
+
+jobs:
+  load-test:
+    name: Load test relayer against Fuji
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout icm-services
+        uses: actions/checkout@v7
+
+      - name: Checkout load simulator
+        uses: actions/checkout@v7
+        with:
+          repository: ava-labs/icm-relayer-load-simulator
+          ref: ${{ inputs.load-sim-ref }}
+          token: ${{ secrets.LOAD_SIM_CHECKOUT_TOKEN }}
+          path: load-sim
+          submodules: recursive
+
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: "go.mod"
+
+      - name: Build relayer
+        # constants.sh sets the repo's standard build environment; sourcing it
+        # matches how the release workflow builds the same binary.
+        run: |
+          source ./scripts/constants.sh
+          ./scripts/build_relayer.sh
+          ./build/icm-relayer --version
+
+      - name: Render configs
+        env:
+          FUJI_API_TOKEN: ${{ secrets.FUJI_API_TOKEN }}
+          ECHO_RPC_TOKEN: ${{ secrets.ECHO_RPC_TOKEN }}
+          DISPATCH_RPC_TOKEN: ${{ secrets.DISPATCH_RPC_TOKEN }}
+          FUJI_LOAD_WALLETS: ${{ secrets.FUJI_LOAD_WALLETS }}
+        run: |
+          for var in FUJI_API_TOKEN ECHO_RPC_TOKEN DISPATCH_RPC_TOKEN FUJI_LOAD_WALLETS; do
+            if [ -z "${!var}" ]; then
+              echo "::error::Required secret $var is not set"
+              exit 1
+            fi
+          done
+          envsubst '$FUJI_API_TOKEN $ECHO_RPC_TOKEN $DISPATCH_RPC_TOKEN' \
+            < load-sim/config/fuji/load_config.template.json \
+            | jq --argjson wallets "$FUJI_LOAD_WALLETS" '.wallets = $wallets' \
+            > load-sim/load_config.json
+          # The relayer validates every configured chain at startup, so an
+          # unrelated-but-unhealthy chain would kill the run. Keep only the
+          # two chains this run uses.
+          SRC_ID=$(jq -r --arg c "${{ inputs.source }}" '."chain-info"[$c].blockchain_id' load-sim/load_config.json)
+          DEST_ID=$(jq -r --arg c "${{ inputs.destination }}" '."chain-info"[$c].blockchain_id' load-sim/load_config.json)
+          envsubst '$FUJI_API_TOKEN $ECHO_RPC_TOKEN $DISPATCH_RPC_TOKEN' \
+            < load-sim/config/fuji/relayer_config.template.json \
+            | jq --arg src "$SRC_ID" --arg dest "$DEST_ID" '
+                .["source-blockchains"]      |= map(select(.["blockchain-id"] == $src)) |
+                .["destination-blockchains"] |= map(select(.["blockchain-id"] == $dest))' \
+            > load-sim/relayer_config.json
+
+      - name: Run load test
+        working-directory: load-sim
+        env:
+          # Signing key for the relayer's delivery transactions on the destination chain
+          ACCOUNT_PRIVATE_KEY: ${{ secrets.FUJI_RELAYER_PRIVATE_KEY }}
+        run: |
+          set -o pipefail
+          mkdir -p results
+          go run . \
+            --sender="${{ inputs.source }}" \
+            --receiver="${{ inputs.destination }}" \
+            --count="${{ inputs.count }}" \
+            --rate="${{ inputs.rate }}" \
+            --timeout="${{ inputs.timeout }}" \
+            --run-relayer \
+            --relayer-exe="$GITHUB_WORKSPACE/build/icm-relayer" \
+            --relayer-config=./relayer_config.json \
+            --load-config=./load_config.json \
+            --output=./results \
+            --report=ci \
+            --message="gh-run=${{ github.run_id }}" \
+            2>&1 | tee results/run.log
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: load-test-results-${{ github.run_id }}
+          path: |
+            load-sim/results/
+            !load-sim/results/**/*.prof
+          if-no-files-found: warn
+          retention-days: 30


### PR DESCRIPTION
## Why this should be merged
Right now, load testing the relayer against a real network is a manual chore. You have to clone the load simulator, build a relayer binary, hand write two config files, fund wallets, run everything locally, and then read the results off your terminal. This PR adds a manually triggered workflow that gives us a repeatable regression test for the relayer against Fuji, using real chains, real validators, and real signature aggregation.

## How this works
The workflow is triggered by hand from the Actions tab. You pick a source chain, a destination chain, a message count, and a send rate. It then:

1. Checks out this repo at whtevder branch you dispatched it from, and builds the relayer from source
2. Checks out the icm-relayer-load-simulator repo (private, so it needs a PAT)
3. Renders the relayer and load tester configs from templates in the simulator repo, filling in RPC tokens and wallet keys from repository secrets.
4. Runs the load test. The simulator starts the relayer, sends messages through small Sender and Receiver contracts deployed on Fuji C-Chain and Echo (Dispatch has been down, but will add that soon), and watches the relayer logs for deliveries.
5. Writes a pass/fail verdict and latency table to the run's step summary, and uploads the raw CSVs and logs as an artifact. The job fails if any sent message is not delivered.

Only one run can be active at a time, since the runs share wallets and would otherwise collide on nonces.

The following repository secrets need to be set before the first run:

- LOAD_SIM_CHECKOUT_TOKEN: a fine grained PAT with read access to the load simulator repo
- FUJI_API_TOKEN, ECHO_RPC_TOKEN, DISPATCH_RPC_TOKEN: bearer tokens for our dedicated Fuji API endpoints
- FUJI_RELAYER_PRIVATE_KEY: the key the relayer signs delivery transactions with, funded on each destination chain
- FUJI_LOAD_WALLETS: a JSON list of funded wallets the load tester sends from

## How this was tested
The workflow's steps are mirrored one to one in a script locally, and that script was run repeatedly against Fuji with the same config rendering, same relayer build flags, same flags to the load tester, same pass/fail logic. We have to see the result on GitHub Actions to confirm.

## How is this documented