### PR TITLE
Fetch live-block logs over WS instead of HTTP

### DIFF
--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -32,6 +32,9 @@ type SubscriberRPCClient interface {
 
 type SubscriberWSClient interface {
 	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error)
+	// Used to fetch logs for live blocks; see blocksInfoFromHeaders for why
+	// these fetches must use the WS connection.
+	ethereum.LogFilterer
 }
 
 type Subscriber struct {
@@ -201,7 +204,14 @@ func (s *Subscriber) subscribe(retryTimeout time.Duration) error {
 // and writes them to the blocks channel consumed by the listener
 func (s *Subscriber) blocksInfoFromHeaders() {
 	for header := range s.headers {
-		block, err := relayerTypes.NewICMBlockInfo(s.logger, header, s.rpcClient, s.topics, s.isPrimaryNetwork)
+		// Fetch logs over the WS connection rather than the HTTP client: the
+		// node that emitted this head is guaranteed to have the block's
+		// receipts on disk, whereas an HTTP request may be routed to a
+		// different node behind a load balancer that has not yet executed the
+		// block. On SAE chains such a node returns empty logs without an
+		// error, which would cause this block's messages to be silently
+		// skipped.
+		block, err := relayerTypes.NewICMBlockInfo(s.logger, header, s.wsClient, s.topics, s.isPrimaryNetwork)
 		if err != nil {
 			s.errChan <- fmt.Errorf("creating warp block info: %w", err)
 			return


### PR DESCRIPTION
## Why this should be merged
The relayer subscribes to newHeads over the websocket endpoint but fetches each block's logs over the separate HTTP endpoint. Behind a load balanced RPC service these are different connections: the websocket is pinned to one node, while every HTTP request can land on any node in the pool.

Before SAE, the C-Chain was served by coreth, which refuses queries past its accepted tip with an explicit error, and the relayer retries on errors. The SAE VM serves the same APIs through stock go-ethereum filter code (via libevm), which has no such guard: eth_getLogs for a block the node has not executed returns an empty result with no error. The relayer treats empty as "no messages in this block", commits the height, and never revisits it. Our relayers do error detection based on errors returned by the endpoints, and they treat empty bodies as "none found".

Tracing how a call gets handled: https://app.excalidraw.com/s/6EdLWQu96F6/6PgBbN3Oa5i

## How this works
The node that emitted a newHeads event is guaranteed to have that block's receipts on disk (the SAE executor writes receipts before publishing the head event), so fetching logs over the same websocket connection cannot race. This change does exactly that, for the live path only.

**NOTE**: This is the quickest fix I could think of, but there are other candidates. The crux of the issue is that before, we could rely on the node returning an error if they didn't know about a block, prompting the relayer to retry. The issue isn't that the nodes behind the load balancer can be out of sync, but for SAE, that they no longer are compatible with tooling built for coreth.

## How this was tested
Measured on Fuji, C-Chain to Echo, 100 messages at 5/s through the token gated endpoints: current main delivered 88/100 (12 messages silently skipped, zero errors logged); with this change 100/100.

## How is this documented
N/A