### PR TITLE
Catch up

### DIFF
--- a/relayer/listener.go
+++ b/relayer/listener.go
@@ -142,7 +142,7 @@ func newListener(
 		blockchainID,
 		sourceBlockchain.GetSubnetID() == constants.PrimaryNetworkID,
 		evm.NewWSHeadClient(wsRPCClient),
-		ethRPCClient,
+		evm.NewRPCHeadClient(ethRPCClient),
 		errChan,
 		EventFilterForProtocol(protocol),
 	)

--- a/vms/evm/subscriber.go
+++ b/vms/evm/subscriber.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ava-labs/icm-services/utils"
 	ethereum "github.com/ava-labs/libevm"
 	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/common/hexutil"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/ethclient"
 	"github.com/ava-labs/libevm/rpc"
@@ -25,11 +26,46 @@ const (
 	// Max buffer size for ethereum subscription channels
 	maxClientSubscriptionBuffer = 20000
 	MaxBlocksPerRequest         = 200
+
+	// strictTailBlocks is the number of most recent blocks of a catch-up range
+	// that are processed block-by-block (existence check by number, logs by
+	// node-reported hash) instead of via by-number range queries. Nodes behind
+	// a load-balanced endpoint may briefly disagree about the newest blocks,
+	// and a range query served by a lagging node silently omits blocks it does
+	// not yet have. Observed skew is sub-second; 10 blocks is a generous
+	// margin. Blocks older than this exist on every node, so range queries
+	// remain safe and fast for deep history.
+	strictTailBlocks = 10
 )
 
 type SubscriberRPCClient interface {
 	BlockNumber(ctx context.Context) (uint64, error)
+	// HeadByNumber returns the block head with its node-reported hash, or an
+	// error — ethereum.NotFound when the serving node does not have the block,
+	// which callers treat as retryable.
+	HeadByNumber(ctx context.Context, number *big.Int) (*relayerTypes.BlockHead, error)
 	ethereum.LogFilterer
+}
+
+// RPCHeadClient augments an ethclient with verbatim-hash head fetches by
+// number, satisfying SubscriberRPCClient. The hash must come from the node
+// rather than be recomputed client-side, which is unreliable for chains whose
+// headers carry fields this client cannot encode (e.g. SAE chains).
+type RPCHeadClient struct {
+	*ethclient.Client
+}
+
+func NewRPCHeadClient(client *ethclient.Client) RPCHeadClient {
+	return RPCHeadClient{Client: client}
+}
+
+func (c RPCHeadClient) HeadByNumber(ctx context.Context, number *big.Int) (*relayerTypes.BlockHead, error) {
+	var head *relayerTypes.BlockHead
+	err := c.Client.Client().CallContext(ctx, &head, "eth_getBlockByNumber", hexutil.EncodeBig(number), false)
+	if err == nil && head == nil {
+		err = ethereum.NotFound
+	}
+	return head, err
 }
 
 type SubscriberWSClient interface {
@@ -118,16 +154,72 @@ func (s *Subscriber) ProcessFromHeight(startingHeight uint64, endingHeight uint6
 	)
 	log.Info("Processing historical logs")
 
-	for fromBlock := startingHeight; fromBlock <= endingHeight; fromBlock += MaxBlocksPerRequest {
-		toBlock := min(fromBlock+MaxBlocksPerRequest-1, endingHeight)
+	if endingHeight < startingHeight {
+		log.Info("Finished processing historical logs")
+		return
+	}
 
-		err := s.processBlockRange(fromBlock, toBlock)
-		if err != nil {
-			s.errChan <- fmt.Errorf("failed to process block range: %w", err)
+	// Range queries are only trustworthy for blocks old enough that every node
+	// behind a load-balanced endpoint has them; the newest blocks are checked
+	// strictly, one by one. See strictTailBlocks.
+	strictStart := startingHeight
+	if endingHeight-startingHeight+1 > strictTailBlocks {
+		strictStart = endingHeight - strictTailBlocks + 1
+		for fromBlock := startingHeight; fromBlock < strictStart; fromBlock += MaxBlocksPerRequest {
+			toBlock := min(fromBlock+MaxBlocksPerRequest-1, strictStart-1)
+
+			err := s.processBlockRange(fromBlock, toBlock)
+			if err != nil {
+				s.errChan <- fmt.Errorf("failed to process block range: %w", err)
+				return
+			}
+		}
+	}
+
+	for height := strictStart; height <= endingHeight; height++ {
+		if err := s.processBlockStrict(height); err != nil {
+			s.errChan <- fmt.Errorf("failed to process block %d: %w", height, err)
 			return
 		}
 	}
 	log.Info("Finished processing historical logs")
+}
+
+// processBlockStrict processes a single block with the same guarantees as the
+// live path: existence is confirmed by number (a node that does not have the
+// block answers ethereum.NotFound, which is retried) and logs are fetched by
+// the node-reported hash. A by-number range query over these blocks could be
+// served by a lagging node and silently omit them.
+func (s *Subscriber) processBlockStrict(height uint64) error {
+	var head *relayerTypes.BlockHead
+	operation := func() (err error) {
+		cctx, cancel := context.WithTimeout(context.Background(), utils.DefaultRPCTimeout)
+		defer cancel()
+		head, err = s.rpcClient.HeadByNumber(cctx, new(big.Int).SetUint64(height))
+		return err
+	}
+	notify := func(err error, duration time.Duration) {
+		s.logger.Info(
+			"get head by number failed, retrying...",
+			zap.Uint64("blockNumber", height),
+			zap.Duration("retryIn", duration),
+			zap.Error(err),
+		)
+	}
+
+	// Same window as the live path: heads near the chain tip may not yet be
+	// known to every node behind a load-balanced endpoint.
+	if err := utils.WithRetriesTimeout(operation, notify, utils.DefaultRPCTimeout*6); err != nil {
+		return fmt.Errorf("failed to get head for block %d: %w", height, err)
+	}
+
+	block, err := relayerTypes.NewICMBlockInfo(s.logger, head, s.rpcClient, s.topics, s.isPrimaryNetwork)
+	if err != nil {
+		return err
+	}
+	block.IsCatchup = true
+	s.icmBlocks <- block
+	return nil
 }
 
 // Process Warp messages from the block range [fromBlock, toBlock], inclusive

--- a/vms/evm/subscriber_test.go
+++ b/vms/evm/subscriber_test.go
@@ -5,6 +5,7 @@ package evm
 
 import (
 	"context"
+	"math/big"
 	"testing"
 
 	"github.com/ava-labs/avalanchego/ids"
@@ -14,6 +15,7 @@ import (
 	stypes "github.com/ava-labs/icm-services/types"
 	ethereum "github.com/ava-labs/libevm"
 	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/common/hexutil"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/stretchr/testify/require"
 )
@@ -25,10 +27,19 @@ type subscriberClientStub struct {
 	blockNumber                 uint64
 	numFilterLogCalls           int
 	numSubscribeFilterLogsCalls int
+	numHeadByNumberCalls        int
 }
 
 func (c *subscriberClientStub) BlockNumber(ctx context.Context) (uint64, error) {
 	return c.blockNumber, nil
+}
+
+func (c *subscriberClientStub) HeadByNumber(ctx context.Context, number *big.Int) (*stypes.BlockHead, error) {
+	c.numHeadByNumberCalls++
+	return &stypes.BlockHead{
+		Hash:   common.BigToHash(number),
+		Number: (*hexutil.Big)(new(big.Int).Set(number)),
+	}, nil
 }
 
 func (c *subscriberClientStub) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
@@ -109,6 +120,21 @@ func TestProcessFromHeight(t *testing.T) {
 			input:  41,
 		},
 		{
+			name:   "span smaller than strict tail",
+			latest: 50,
+			input:  45,
+		},
+		{
+			name:   "span exactly the strict tail",
+			latest: 50,
+			input:  41,
+		},
+		{
+			name:   "span one greater than strict tail",
+			latest: 50,
+			input:  40,
+		},
+		{
 			name:   "invalid starting block number",
 			latest: 50,
 			input:  51,
@@ -121,22 +147,38 @@ func TestProcessFromHeight(t *testing.T) {
 			subscriberUnderTest, stubRPCClient := makeSubscriberWithMockEthClient(t, errChan)
 
 			stubRPCClient.blockNumber = tc.latest
-			var expectedFilterLogCalls uint64
-			if tc.latest > tc.input {
-				expectedFilterLogCalls = (tc.latest-tc.input+1)/MaxBlocksPerRequest + 1
+
+			// The last strictTailBlocks blocks are processed one by one via
+			// HeadByNumber (no FilterLogs here: the stub's bloom is empty and
+			// the test chain is not the primary network, so the bloom gate
+			// skips the log fetch); everything older is served by chunked
+			// range queries.
+			var expectedFilterLogCalls, expectedHeadCalls uint64
+			if tc.latest >= tc.input {
+				span := tc.latest - tc.input + 1
+				if span > strictTailBlocks {
+					expectedHeadCalls = strictTailBlocks
+					rangeSpan := span - strictTailBlocks
+					expectedFilterLogCalls = (rangeSpan + MaxBlocksPerRequest - 1) / MaxBlocksPerRequest
+				} else {
+					expectedHeadCalls = span
+				}
 			}
+
 			subscriberUnderTest.ProcessFromHeight(tc.input, tc.latest)
 			require.Empty(t, errChan)
 
-			if tc.latest > tc.input {
+			if tc.latest >= tc.input {
 				for i := tc.input; i <= tc.latest; i++ {
 					block := <-subscriberUnderTest.ICMBlocks()
 					require.Equal(t, i, block.BlockNumber)
 					require.Empty(t, block.Logs)
+					require.True(t, block.IsCatchup)
 				}
 			}
 			require.Zero(t, len(subscriberUnderTest.ICMBlocks()))
 			require.EqualValues(t, expectedFilterLogCalls, stubRPCClient.numFilterLogCalls)
+			require.EqualValues(t, expectedHeadCalls, stubRPCClient.numHeadByNumberCalls)
 		})
 	}
 }


### PR DESCRIPTION
## Why this should be merged
This closes the second half of the message loss issue on chains that serve geth style RPC. The live path fix (fetching logs by node reported block hash) covers blocks arriving over the websocket, but catch-up still queries logs by block number ranges. The upper end of a catch-up range is anchored to the newest block announced by the websocket node, and the HTTP request serving that range can land on a node that has not seen the newest blocks yet.

## How this works
Catch-up now splits the range in two. Everything except the last 10 blocks is processed exactly as before, with chunked range queries. Blocks old enough to be behind every node's view are safe to query this way, and going block by block over a long outage would be far too slow.

The relayer first fetches the block head by number, which returns a NotFound error when the serving node does not have the block yet, and retries until a node that has it answers. The head carries the node reported block hash, and the logs are then fetched by that hash, where an unknown hash is again an explicit, retried error. The hash has to come from the node because recomputing it client side does not work for chains whose headers carry fields this client cannot encode.

The 10 block boundary is a deliberate margin: measured disagreement between nodes behind our endpoints is sub-second, and 10 blocks is roughly 10 to 20 seconds of tolerated lag on the C-Chain. Spans of 10 blocks or fewer, which is what a typical reconnect produces, are processed entirely in strict mode. Can toggle this up or down as needed.

The only wiring change is wrapping the existing HTTP client so it can also fetch heads by number.

## How this was tested
Unit tests and load testing. I added a catch-up version to the load test scenario.

## How is this documented