### PR TITLE
tighten if condition

### DIFF
--- a/scripts/install_avalanchego_release.sh
+++ b/scripts/install_avalanchego_release.sh
@@ -72,8 +72,11 @@ else
     rm -f ${AVAGO_DOWNLOAD_PATH}
   fi
 
-  # try to download the archive if it exists
-  if curl -s --head --request GET ${AVAGO_DOWNLOAD_URL} | grep "302" > /dev/null; then
+  # Try to download the archive if it exists. GitHub responds to existing
+  # release asset requests with a 302 redirect to the actual download; check
+  # the HTTP status code explicitly rather than grepping the headers for
+  # "302", which can false-positive on substrings of unrelated header values.
+  if [[ "$(curl -s -o /dev/null -w '%{http_code}' -I ${AVAGO_DOWNLOAD_URL})" == "302" ]]; then
     echo "${AVAGO_DOWNLOAD_URL} found"
     echo "downloading to ${AVAGO_DOWNLOAD_PATH}"
     if ! curl -f -L ${AVAGO_DOWNLOAD_URL} -o ${AVAGO_DOWNLOAD_PATH}; then


### PR DESCRIPTION
## Why this should be merged
Currently, the CI script `grep`s all response headers when trying to download. This causes flakiness, because we use status code "302", meaning a redirect, to detect whether a given commit hash corresponds to a release or not. However, if a given commit doesn't have a release but some other headers in the response contain "302" somewhere in their strings, it will cause a false positive. Then, the script will try to fetch it, getting a 404.

## How this works
This PR fixes this by specifically only grepping the status code.

## How this was tested
The old script caused a false positive right around the time when the UNIX epoch contained "302". It was replicated at another point that also contained "302". The new if condition didn't, have this issue, but works the same on the happy path.

## How is this documented