### PR TITLE
Fix e2e test flakes

### DIFF
--- a/icm-contracts/tests/flows/services/validators_only_network.go
+++ b/icm-contracts/tests/flows/services/validators_only_network.go
@@ -303,7 +303,6 @@ func waitForNodesToReconnect(
 			log.Info("Waiting for restarted node to reconnect to its peers",
 				zap.Stringer("nodeID", tmpnetNode.NodeID),
 				zap.Any("missingPeers", missing),
-				zap.Error(err),
 			)
 			select {
 			case <-cctx.Done():

--- a/icm-contracts/tests/flows/services/validators_only_network.go
+++ b/icm-contracts/tests/flows/services/validators_only_network.go
@@ -277,6 +277,10 @@ func waitForNodesToReconnect(
 		}
 		infoClient := info.NewClient(tmpnetNode.URI)
 		for {
+			if cctx.Err() != nil {
+				Expect(false).Should(BeTrue(), "timed out waiting for restarted nodes to reconnect")
+			}
+
 			peers, err := infoClient.Peers(cctx, nil)
 			if err != nil {
 				log.Error("Failed to get peers from node",

--- a/icm-contracts/tests/flows/services/validators_only_network.go
+++ b/icm-contracts/tests/flows/services/validators_only_network.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/ava-labs/avalanchego/api/info"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/staking"
 	"github.com/ava-labs/avalanchego/utils/logging"
@@ -102,7 +103,7 @@ func ValidatorsOnlyNetwork(
 
 	// Wait for signature-aggregator to start up
 	log.Info("Waiting for the signature-aggregator to start up")
-	startupCtx, startupCancel := context.WithTimeout(ctx, 15*time.Second)
+	startupCtx, startupCancel := context.WithTimeout(ctx, 60*time.Second)
 	defer startupCancel()
 	utils.WaitForChannelClose(startupCtx, readyChan)
 
@@ -159,6 +160,12 @@ func ValidatorsOnlyNetwork(
 			Expect(err).Should(BeNil())
 		}
 	}
+
+	// The signature aggregator's readiness health check requires a quorum of l1B stake to be
+	// connected, and with one of the equal-weight validators intentionally underfunded the margin
+	// is a single node. Wait for the restarted validators to re-establish their p2p connections
+	// before starting the aggregator so its initial dials don't race the restarts.
+	waitForNodesToReconnect(ctx, log, network, l1BNodes)
 
 	// End setup step
 
@@ -228,7 +235,7 @@ func ValidatorsOnlyNetwork(
 
 	// Wait for signature-aggregator to start up
 	log.Info("Waiting for the signature-aggregator to start up")
-	startupCtx, startupCancel = context.WithTimeout(ctx, 15*time.Second)
+	startupCtx, startupCancel = context.WithTimeout(ctx, 60*time.Second)
 	defer startupCancel()
 	utils.WaitForChannelClose(startupCtx, readyChan)
 
@@ -247,11 +254,65 @@ func ValidatorsOnlyNetwork(
 
 	// Wait for signature-aggregator to start up
 	log.Info("Waiting for the signature-aggregator to start up")
-	startupCtx, startupCancel = context.WithTimeout(ctx, 15*time.Second)
+	startupCtx, startupCancel = context.WithTimeout(ctx, 60*time.Second)
 	defer startupCancel()
 	utils.WaitForChannelClose(startupCtx, readyChan)
 
 	sendRequestToAPI(true)
+}
+
+// waitForNodesToReconnect blocks until every node in [nodeIDs] reports every other node in
+// [nodeIDs] as a connected peer, or fails the test after a timeout.
+func waitForNodesToReconnect(
+	ctx context.Context,
+	log logging.Logger,
+	network *network.LocalAvalancheNetwork,
+	nodeIDs set.Set[ids.NodeID],
+) {
+	cctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
+	for _, tmpnetNode := range network.Nodes {
+		if !nodeIDs.Contains(tmpnetNode.NodeID) {
+			continue
+		}
+		infoClient := info.NewClient(tmpnetNode.URI)
+		for {
+			peers, err := infoClient.Peers(cctx, nil)
+			if err != nil {
+				log.Error("Failed to get peers from node",
+					zap.Stringer("nodeID", tmpnetNode.NodeID),
+					zap.Error(err),
+				)
+				continue
+			}
+
+			connected := set.NewSet[ids.NodeID](len(peers))
+			for _, peer := range peers {
+				connected.Add(peer.ID)
+			}
+			var missing []ids.NodeID
+			for _, want := range nodeIDs.List() {
+				if want != tmpnetNode.NodeID && !connected.Contains(want) {
+					missing = append(missing, want)
+				}
+			}
+			if len(missing) == 0 {
+				break
+			}
+
+			log.Info("Waiting for restarted node to reconnect to its peers",
+				zap.Stringer("nodeID", tmpnetNode.NodeID),
+				zap.Any("missingPeers", missing),
+				zap.Error(err),
+			)
+			select {
+			case <-cctx.Done():
+				Expect(false).Should(BeTrue(), "timed out waiting for restarted nodes to reconnect")
+			case <-time.After(time.Second):
+			}
+		}
+	}
+	log.Info("Restarted nodes reconnected to their peers")
 }
 
 func getUnderfundedNodeIndexes(

--- a/icm-contracts/tests/utils/services_utils.go
+++ b/icm-contracts/tests/utils/services_utils.go
@@ -210,6 +210,9 @@ func CreateDefaultRelayerConfig(
 		AllowPrivateIPs:                 true,
 		InitialConnectionTimeoutSeconds: 300,
 		MaxConcurrentMessages:           250,
+		// Refresh tracked validators frequently so tests that restarted nodes
+		// re-establish connections quickly.
+		ValidatorRefreshPeriodSeconds: 5,
 	}
 }
 
@@ -243,6 +246,9 @@ func CreateDefaultSignatureAggregatorConfig(
 		SignatureCacheSize: (1024 * 1024),
 		AllowPrivateIPs:    true,
 		MaxPChainLookback:  -1,
+		// Refresh tracked validators frequently so tests that restarted nodes
+		// re-establish connections quickly.
+		ValidatorRefreshPeriodSeconds: 5,
 	}
 }
 

--- a/peers/app_request_network.go
+++ b/peers/app_request_network.go
@@ -40,7 +40,6 @@ import (
 
 const (
 	InboundMessageChannelSize = 1000
-	ValidatorRefreshPeriod    = time.Minute * 1
 	ValidatorPreFetchPeriod   = time.Second * 5
 	NumBootstrapNodes         = 5
 	// Maximum number of subnets that can be tracked by the app request network
@@ -222,11 +221,6 @@ func NewNetwork(
 
 	validatorManager := NewValidatorManager(cfg, logger, metrics, int(validatorSetsCacheSize), manager)
 
-	validatorRefreshPeriod := cfg.GetValidatorRefreshPeriod()
-	if validatorRefreshPeriod <= 0 {
-		validatorRefreshPeriod = ValidatorRefreshPeriod
-	}
-
 	arNetwork := &AppRequestNetwork{
 		network:                testNetwork,
 		handler:                handler,
@@ -235,7 +229,7 @@ func NewNetwork(
 		trackedSubnets:         localTrackedSubnets,
 		trackedSubnetsLock:     trackedSubnetsLock,
 		lruSubnets:             lruSubnets,
-		validatorRefreshPeriod: validatorRefreshPeriod,
+		validatorRefreshPeriod: cfg.GetValidatorRefreshPeriod(),
 		validatorManager:       validatorManager,
 	}
 
@@ -280,7 +274,7 @@ func (n *AppRequestNetwork) TrackSubnet(ctx context.Context, subnetID ids.ID) {
 func (n *AppRequestNetwork) startUpdateTrackedValidators(ctx context.Context) {
 	// Fetch validators immediately when called, then refresh every validatorRefreshPeriod
 	n.updateTrackedValidatorSets(ctx)
-	ticker := time.NewTicker(ValidatorRefreshPeriod)
+	ticker := time.NewTicker(n.validatorRefreshPeriod)
 	defer ticker.Stop()
 
 	for {

--- a/peers/app_request_network.go
+++ b/peers/app_request_network.go
@@ -69,6 +69,9 @@ type AppRequestNetwork struct {
 	lruSubnets         *linked.Hashmap[ids.ID, interface{}]
 	trackedSubnetsLock *sync.RWMutex
 
+	// validatorRefreshPeriod is the interval between tracked-validator refreshes
+	validatorRefreshPeriod time.Duration
+
 	validatorManager *ValidatorManager
 }
 
@@ -219,15 +222,21 @@ func NewNetwork(
 
 	validatorManager := NewValidatorManager(cfg, logger, metrics, int(validatorSetsCacheSize), manager)
 
+	validatorRefreshPeriod := cfg.GetValidatorRefreshPeriod()
+	if validatorRefreshPeriod <= 0 {
+		validatorRefreshPeriod = ValidatorRefreshPeriod
+	}
+
 	arNetwork := &AppRequestNetwork{
-		network:            testNetwork,
-		handler:            handler,
-		logger:             logger,
-		metrics:            metrics,
-		trackedSubnets:     localTrackedSubnets,
-		trackedSubnetsLock: trackedSubnetsLock,
-		lruSubnets:         lruSubnets,
-		validatorManager:   validatorManager,
+		network:                testNetwork,
+		handler:                handler,
+		logger:                 logger,
+		metrics:                metrics,
+		trackedSubnets:         localTrackedSubnets,
+		trackedSubnetsLock:     trackedSubnetsLock,
+		lruSubnets:             lruSubnets,
+		validatorRefreshPeriod: validatorRefreshPeriod,
+		validatorManager:       validatorManager,
 	}
 
 	go arNetwork.startUpdateTrackedValidators(ctx)
@@ -269,9 +278,10 @@ func (n *AppRequestNetwork) TrackSubnet(ctx context.Context, subnetID ids.ID) {
 }
 
 func (n *AppRequestNetwork) startUpdateTrackedValidators(ctx context.Context) {
-	// Fetch validators immediately when called, and refresh every ValidatorRefreshPeriod
-	ticker := time.NewTicker(ValidatorRefreshPeriod)
+	// Fetch validators immediately when called, then refresh every validatorRefreshPeriod
 	n.updateTrackedValidatorSets(ctx)
+	ticker := time.NewTicker(ValidatorRefreshPeriod)
+	defer ticker.Stop()
 
 	for {
 		select {
@@ -282,6 +292,13 @@ func (n *AppRequestNetwork) startUpdateTrackedValidators(ctx context.Context) {
 			return
 		}
 	}
+}
+
+// getAllSubnets returns the tracked subnets plus the primary network.
+func (n *AppRequestNetwork) getAllSubnets() []ids.ID {
+	n.trackedSubnetsLock.RLock()
+	defer n.trackedSubnetsLock.RUnlock()
+	return append(n.trackedSubnets.List(), constants.PrimaryNetworkID)
 }
 
 func (n *AppRequestNetwork) StartCacheValidatorSets(ctx context.Context) {
@@ -296,12 +313,8 @@ func (n *AppRequestNetwork) updateTrackedValidatorSets(ctx context.Context) {
 		return
 	}
 
-	n.trackedSubnetsLock.RLock()
-	subnets := append(n.trackedSubnets.List(), constants.PrimaryNetworkID)
-	n.trackedSubnetsLock.RUnlock()
-
 	// Update the validators for each tracked subnet for the most recent height
-	for _, subnetID := range subnets {
+	for _, subnetID := range n.getAllSubnets() {
 		vdrs, ok := allValidators[subnetID]
 		if !ok {
 			n.logger.Warn("No validator set found for tracked subnet",
@@ -429,38 +442,44 @@ func (n *AppRequestNetwork) GetSubnetID(ctx context.Context, blockchainID ids.ID
 // GetNetworkHealthFunc returns a health check function for the network
 func (n *AppRequestNetwork) GetNetworkHealthFunc(subnetIDs []ids.ID) func(context.Context) error {
 	return func(ctx context.Context) error {
-		allValidatorSets, err := n.validatorManager.GetAllValidatorSets(
-			ctx,
-			uint64(pchainapi.ProposedHeight),
-		)
-		if err != nil {
-			n.logger.Error("Failed to get all validator sets", zap.Error(err))
-			return fmt.Errorf("failed to get all validator sets: %w", err)
-		}
-
-		for _, subnetID := range subnetIDs {
-			vdrs, ok := allValidatorSets[subnetID]
-			if !ok {
-				n.logger.Error("No validators for subnet", zap.Stringer("subnetID", subnetID))
-				return fmt.Errorf("no validators for subnet %s", subnetID)
-			}
-			canonicalSet := n.buildCanonicalValidators(vdrs)
-
-			if !utils.CheckStakeWeightExceedsThreshold(
-				big.NewInt(0).SetUint64(canonicalSet.ConnectedWeight),
-				canonicalSet.ValidatorSet.TotalWeight,
-				warp.WarpDefaultQuorumNumerator,
-			) {
-				n.logger.Error("Not enough connected stake for subnet",
-					zap.Stringer("subnetID", subnetID),
-					zap.Uint64("connectedWeight", canonicalSet.ConnectedWeight),
-					zap.Uint64("totalWeight", canonicalSet.ValidatorSet.TotalWeight),
-				)
-				return ErrNotEnoughConnectedStake
-			}
-		}
-		return nil
+		return n.checkConnectedStake(ctx, subnetIDs)
 	}
+}
+
+// checkConnectedStake returns an error if the network is not connected to a default quorum of
+// stake for any of the given subnets, at the proposed P-Chain height.
+func (n *AppRequestNetwork) checkConnectedStake(ctx context.Context, subnetIDs []ids.ID) error {
+	allValidatorSets, err := n.validatorManager.GetAllValidatorSets(
+		ctx,
+		uint64(pchainapi.ProposedHeight),
+	)
+	if err != nil {
+		n.logger.Error("Failed to get all validator sets", zap.Error(err))
+		return fmt.Errorf("failed to get all validator sets: %w", err)
+	}
+
+	for _, subnetID := range subnetIDs {
+		vdrs, ok := allValidatorSets[subnetID]
+		if !ok {
+			n.logger.Error("No validators for subnet", zap.Stringer("subnetID", subnetID))
+			return fmt.Errorf("no validators for subnet %s", subnetID)
+		}
+		canonicalSet := n.buildCanonicalValidators(vdrs)
+
+		if !utils.CheckStakeWeightExceedsThreshold(
+			big.NewInt(0).SetUint64(canonicalSet.ConnectedWeight),
+			canonicalSet.ValidatorSet.TotalWeight,
+			warp.WarpDefaultQuorumNumerator,
+		) {
+			n.logger.Error("Not enough connected stake for subnet",
+				zap.Stringer("subnetID", subnetID),
+				zap.Uint64("connectedWeight", canonicalSet.ConnectedWeight),
+				zap.Uint64("totalWeight", canonicalSet.ValidatorSet.TotalWeight),
+			)
+			return ErrNotEnoughConnectedStake
+		}
+	}
+	return nil
 }
 
 // Non-receiver util functions

--- a/peers/config.go
+++ b/peers/config.go
@@ -5,6 +5,7 @@ package peers
 
 import (
 	"crypto/tls"
+	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/set"
@@ -19,4 +20,5 @@ type Config interface {
 	GetTrackedSubnets() set.Set[ids.ID]
 	GetTLSCert() *tls.Certificate
 	GetMaxPChainLookback() int64
+	GetValidatorRefreshPeriod() time.Duration
 }

--- a/relayer/config/config.go
+++ b/relayer/config/config.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/ava-labs/avalanchego/graft/subnet-evm/params"
 	"github.com/ava-labs/avalanchego/graft/subnet-evm/precompile/contracts/warp"
@@ -41,6 +42,7 @@ const (
 	defaultSignatureCacheSize              = uint64(1024 * 1024)
 	defaultInitialConnectionTimeoutSeconds = uint64(300)
 	defaultMaxConcurrentMessages           = uint64(250)
+	defaultValidatorRefreshPeriodSeconds   = uint64(60)
 )
 
 var defaultLogLevel = logging.Info.String()
@@ -79,6 +81,7 @@ type Config struct {
 	TLSKeyPath                      string                    `mapstructure:"tls-key-path" json:"tls-key-path,omitempty"`
 	InitialConnectionTimeoutSeconds uint64                    `mapstructure:"initial-connection-timeout-seconds" json:"initial-connection-timeout-seconds,omitempty"` // nolint:lll
 	MaxConcurrentMessages           uint64                    `mapstructure:"max-concurrent-messages" json:"max-concurrent-messages,omitempty"`                       //nolint:lll
+	ValidatorRefreshPeriodSeconds   uint64                    `mapstructure:"validator-refresh-period-seconds" json:"validator-refresh-period-seconds,omitempty"`     //nolint:lll
 	ExternalEVMDestinations         []*ExternalEVMDestination `mapstructure:"external-evm-destinations" json:"external-evm-destinations,omitempty"`                   //nolint:lll
 
 	// convenience field to fetch a blockchain's subnet ID
@@ -358,6 +361,10 @@ func (c *Config) LogSafeField() zap.Field {
 
 func (c *Config) GetMaxPChainLookback() int64 {
 	return -1 // No max lookback for relayer
+}
+
+func (c *Config) GetValidatorRefreshPeriod() time.Duration {
+	return time.Duration(c.ValidatorRefreshPeriodSeconds) * time.Second
 }
 
 func (c *Config) sanitizeForLogging() map[string]any {

--- a/relayer/config/keys.go
+++ b/relayer/config/keys.go
@@ -24,4 +24,5 @@ const (
 	SignatureCacheSizeKey              = "signature-cache-size"
 	InitialConnectionTimeoutSecondsKey = "initial-connection-timeout-seconds"
 	MaxConcurrentMessagesKey           = "max-concurrent-messages"
+	ValidatorRefreshPeriodSecondsKey   = "validator-refresh-period-seconds"
 )

--- a/relayer/config/viper.go
+++ b/relayer/config/viper.go
@@ -64,6 +64,7 @@ func SetDefaultConfigValues(v *viper.Viper) {
 	)
 	v.SetDefault(InitialConnectionTimeoutSecondsKey, defaultInitialConnectionTimeoutSeconds)
 	v.SetDefault(MaxConcurrentMessagesKey, defaultMaxConcurrentMessages)
+	v.SetDefault(ValidatorRefreshPeriodSecondsKey, defaultValidatorRefreshPeriodSeconds)
 }
 
 // BuildConfig constructs the relayer config using Viper.

--- a/signature-aggregator/config/config.go
+++ b/signature-aggregator/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"crypto/tls"
 	"fmt"
+	"time"
 
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/logging"
@@ -18,8 +19,9 @@ const (
 	defaultAPIPort     = uint16(8080)
 	defaultMetricsPort = uint16(8081)
 
-	DefaultSignatureCacheSize = uint64(1024 * 1024)
-	DefaultMaxPChainLookback  = int64(1000)
+	DefaultSignatureCacheSize            = uint64(1024 * 1024)
+	DefaultMaxPChainLookback             = int64(1000)
+	DefaultValidatorRefreshPeriodSeconds = uint64(60)
 )
 
 var defaultLogLevel = logging.Info.String()
@@ -32,18 +34,19 @@ signature-aggregator --help                                  Display signature-a
 `
 
 type Config struct {
-	LogLevel             string                `mapstructure:"log-level" json:"log-level"`
-	PChainAPI            *basecfg.APIConfig    `mapstructure:"p-chain-api" json:"p-chain-api"`
-	InfoAPI              *basecfg.APIConfig    `mapstructure:"info-api" json:"info-api"`
-	APIPort              uint16                `mapstructure:"api-port" json:"api-port"`
-	MetricsPort          uint16                `mapstructure:"metrics-port" json:"metrics-port"`
-	SignatureCacheSize   uint64                `mapstructure:"signature-cache-size" json:"signature-cache-size"`
-	AllowPrivateIPs      bool                  `mapstructure:"allow-private-ips" json:"allow-private-ips"`
-	TrackedSubnetIDs     []string              `mapstructure:"tracked-subnet-ids" json:"tracked-subnet-ids"`
-	TLSCertPath          string                `mapstructure:"tls-cert-path" json:"tls-cert-path,omitempty"`
-	TLSKeyPath           string                `mapstructure:"tls-key-path" json:"tls-key-path,omitempty"`
-	ManuallyTrackedPeers []*basecfg.PeerConfig `mapstructure:"manually-tracked-peers" json:"manually-tracked-peers"`
-	MaxPChainLookback    int64                 `mapstructure:"max-p-chain-lookback" json:"max-p-chain-lookback"`
+	LogLevel                      string                `mapstructure:"log-level" json:"log-level"`
+	PChainAPI                     *basecfg.APIConfig    `mapstructure:"p-chain-api" json:"p-chain-api"`
+	InfoAPI                       *basecfg.APIConfig    `mapstructure:"info-api" json:"info-api"`
+	APIPort                       uint16                `mapstructure:"api-port" json:"api-port"`
+	MetricsPort                   uint16                `mapstructure:"metrics-port" json:"metrics-port"`
+	SignatureCacheSize            uint64                `mapstructure:"signature-cache-size" json:"signature-cache-size"`
+	AllowPrivateIPs               bool                  `mapstructure:"allow-private-ips" json:"allow-private-ips"`
+	TrackedSubnetIDs              []string              `mapstructure:"tracked-subnet-ids" json:"tracked-subnet-ids"`
+	TLSCertPath                   string                `mapstructure:"tls-cert-path" json:"tls-cert-path,omitempty"`
+	TLSKeyPath                    string                `mapstructure:"tls-key-path" json:"tls-key-path,omitempty"`
+	ManuallyTrackedPeers          []*basecfg.PeerConfig `mapstructure:"manually-tracked-peers" json:"manually-tracked-peers"` //nolint:lll
+	MaxPChainLookback             int64                 `mapstructure:"max-p-chain-lookback" json:"max-p-chain-lookback"`
+	ValidatorRefreshPeriodSeconds uint64                `mapstructure:"validator-refresh-period-seconds" json:"validator-refresh-period-seconds,omitempty"` //nolint:lll
 
 	// convenience fields
 	trackedSubnets set.Set[ids.ID]
@@ -105,4 +108,8 @@ func (c *Config) GetTLSCert() *tls.Certificate {
 
 func (c *Config) GetMaxPChainLookback() int64 {
 	return c.MaxPChainLookback
+}
+
+func (c *Config) GetValidatorRefreshPeriod() time.Duration {
+	return time.Duration(c.ValidatorRefreshPeriodSeconds) * time.Second
 }

--- a/signature-aggregator/config/keys.go
+++ b/signature-aggregator/config/keys.go
@@ -13,9 +13,10 @@ const (
 	ConfigFileEnvKey = "CONFIG_FILE"
 
 	// Top-level configuration keys
-	LogLevelKey           = "log-level"
-	APIPortKey            = "api-port"
-	MetricsPortKey        = "metrics-port"
-	SignatureCacheSizeKey = "signature-cache-size"
-	MaxPChainLookbackKey  = "max-p-chain-lookback"
+	LogLevelKey                      = "log-level"
+	APIPortKey                       = "api-port"
+	MetricsPortKey                   = "metrics-port"
+	SignatureCacheSizeKey            = "signature-cache-size"
+	MaxPChainLookbackKey             = "max-p-chain-lookback"
+	ValidatorRefreshPeriodSecondsKey = "validator-refresh-period-seconds"
 )

--- a/signature-aggregator/config/viper.go
+++ b/signature-aggregator/config/viper.go
@@ -62,6 +62,10 @@ func SetDefaultConfigValues(v *viper.Viper) {
 		MaxPChainLookbackKey,
 		DefaultMaxPChainLookback,
 	)
+	v.SetDefault(
+		ValidatorRefreshPeriodSecondsKey,
+		DefaultValidatorRefreshPeriodSeconds,
+	)
 }
 
 // BuildConfig constructs the signature aggregator config using Viper.


### PR DESCRIPTION
## Why this should be merged
Increases the timeout to wait for the sig agg to start up

Adds a config variable to set the time between refreshing the validator sets. This is set lower for tests so we can update restarted nodes more quickly.

## How this works

## How this was tested

## How is this documented