### PR TITLE
Add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       weekly-ava-updates:
         patterns:
@@ -23,6 +25,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       weekly-github-actions:
         patterns:


### PR DESCRIPTION
## Why this should be merged
Adds a cooldown of 7 days to dependabot updates in order to minimize risk of including malicious packages.

## How this works

## How this was tested

## How is this documented