### PR TITLE
Protect github token

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - "**"
 
+# No job here writes to the repository; they only read the checkout and report results.
+permissions:
+  contents: read
+
 jobs:
   golangci:
     runs-on: ubuntu-22.04
@@ -19,6 +23,7 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: recursive
+        persist-credentials: false
 
     - name: Setup Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -40,6 +45,7 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
           submodules: recursive
+          persist-credentials: false
 
     - name: Setup Go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -58,10 +64,16 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Install solhint
+      # Pinned so a newly published solhint release cannot change what CI executes;
+      # --ignore-scripts blocks dependency lifecycle scripts on install. This job holds
+      # no secrets and its GITHUB_TOKEN is read-only and not persisted (see above), so a
+      # compromised solhint can at worst falsify lint results for this run.
       run: |
-        npm install solhint -g
+        npm install -g solhint@6.2.4 --ignore-scripts
         solhint --version
 
     - name: Run Lint
@@ -75,6 +87,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install Foundry
         run: ./scripts/install_foundry.sh
@@ -92,6 +105,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
+          persist-credentials: false
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -110,6 +124,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -68,10 +68,6 @@ jobs:
         persist-credentials: false
 
     - name: Install solhint
-      # Pinned so a newly published solhint release cannot change what CI executes;
-      # --ignore-scripts blocks dependency lifecycle scripts on install. This job holds
-      # no secrets and its GITHUB_TOKEN is read-only and not persisted (see above), so a
-      # compromised solhint can at worst falsify lint results for this run.
       run: |
         npm install -g solhint@6.2.4 --ignore-scripts
         solhint --version


### PR DESCRIPTION
## Why this should be merged
Fixes https://claude.ai/security?project=scanproj_019LCMtLJaK3JHExaMcFeX7Z&finding=scan_018ZtbcWNnFGkytCFgch5FPX-3492992

## How this works
Makes it so that `GITHUB_TOKEN` is not available to solhint. I did not pin solhint to a specific commit, because this would have required a lot of extra npm infra

## How this was tested

## How is this documented