### PR TITLE
Don't leak internal info on API errors

### DIFF
--- a/relayer/api/relay_message.go
+++ b/relayer/api/relay_message.go
@@ -51,15 +51,15 @@ func relayMessageAPIHandler(logger logging.Logger, messageCoordinator *relayer.M
 		var req ManualWarpMessageRequest
 		err := json.NewDecoder(r.Body).Decode(&req)
 		if err != nil {
-			logger.Warn("Could not decode request body")
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			logger.Warn("Could not decode request body", zap.Error(err))
+			http.Error(w, "could not decode request body", http.StatusBadRequest)
 			return
 		}
 
 		unsignedMessage, err := utils.UnpackWarpMessage(req.UnsignedMessageBytes)
 		if err != nil {
 			logger.Warn("Error unpacking warp message", zap.Error(err))
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			http.Error(w, "error unpacking warp message", http.StatusBadRequest)
 			return
 		}
 
@@ -85,7 +85,7 @@ func relayMessageAPIHandler(logger logging.Logger, messageCoordinator *relayer.M
 		txHash, err := messageCoordinator.ProcessMessage(sourceMessage)
 		if err != nil {
 			logger.Error("Error processing message", zap.Error(err))
-			http.Error(w, "error processing message: "+err.Error(), http.StatusInternalServerError)
+			http.Error(w, "error processing message", http.StatusInternalServerError)
 			return
 		}
 
@@ -96,7 +96,7 @@ func relayMessageAPIHandler(logger logging.Logger, messageCoordinator *relayer.M
 		)
 		if err != nil {
 			logger.Error("Error marshaling response", zap.Error(err))
-			http.Error(w, "error marshaling response: "+err.Error(), http.StatusInternalServerError)
+			http.Error(w, "error marshaling response", http.StatusInternalServerError)
 			return
 		}
 
@@ -112,28 +112,28 @@ func relayAPIHandler(logger logging.Logger, messageCoordinator *relayer.MessageC
 		var req RelayMessageRequest
 		err := json.NewDecoder(r.Body).Decode(&req)
 		if err != nil {
-			logger.Warn("Could not decode request body")
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			logger.Warn("Could not decode request body", zap.Error(err))
+			http.Error(w, "could not decode request body", http.StatusBadRequest)
 			return
 		}
 
 		blockchainID, err := utils.HexOrCB58ToID(req.BlockchainID)
 		if err != nil {
-			logger.Warn("Invalid blockchainID", zap.String("blockchainID", req.BlockchainID))
-			http.Error(w, "invalid blockchainID: "+err.Error(), http.StatusBadRequest)
+			logger.Warn("Invalid blockchainID", zap.String("blockchainID", req.BlockchainID), zap.Error(err))
+			http.Error(w, "invalid blockchainID", http.StatusBadRequest)
 			return
 		}
 		messageID, err := utils.HexOrCB58ToID(req.MessageID)
 		if err != nil {
-			logger.Warn("Invalid messageID", zap.String("messageID", req.MessageID))
-			http.Error(w, "invalid messageID: "+err.Error(), http.StatusBadRequest)
+			logger.Warn("Invalid messageID", zap.String("messageID", req.MessageID), zap.Error(err))
+			http.Error(w, "invalid messageID", http.StatusBadRequest)
 			return
 		}
 
 		txHash, err := messageCoordinator.ProcessMessageID(blockchainID, messageID, new(big.Int).SetUint64(req.BlockNum))
 		if err != nil {
 			logger.Error("Error processing message", zap.Error(err))
-			http.Error(w, "error processing message: "+err.Error(), http.StatusInternalServerError)
+			http.Error(w, "error processing message", http.StatusInternalServerError)
 			return
 		}
 
@@ -144,7 +144,7 @@ func relayAPIHandler(logger logging.Logger, messageCoordinator *relayer.MessageC
 		)
 		if err != nil {
 			logger.Error("Error marshalling response", zap.Error(err))
-			http.Error(w, "error marshalling response: "+err.Error(), http.StatusInternalServerError)
+			http.Error(w, "error marshalling response", http.StatusInternalServerError)
 			return
 		}
 

--- a/relayer/api/relay_message.go
+++ b/relayer/api/relay_message.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"math/big"
 	"net/http"
+	"strings"
 
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/icm-services/messages"
@@ -17,6 +18,12 @@ const (
 	RelayAPIPath        = "/relay"
 	RelayMessageAPIPath = RelayAPIPath + "/message"
 )
+
+func sanitizeLogValue(value string) string {
+	value = strings.ReplaceAll(value, "\n", "")
+	value = strings.ReplaceAll(value, "\r", "")
+	return value
+}
 
 type RelayMessageRequest struct {
 	// Required. cb58-encoded or "0x" prefixed hex-encoded source blockchain ID for the message
@@ -119,13 +126,13 @@ func relayAPIHandler(logger logging.Logger, messageCoordinator *relayer.MessageC
 
 		blockchainID, err := utils.HexOrCB58ToID(req.BlockchainID)
 		if err != nil {
-			logger.Warn("Invalid blockchainID", zap.String("blockchainID", req.BlockchainID), zap.Error(err))
+			logger.Warn("Invalid blockchainID", zap.String("blockchainID", sanitizeLogValue(req.BlockchainID)), zap.Error(err))
 			http.Error(w, "invalid blockchainID", http.StatusBadRequest)
 			return
 		}
 		messageID, err := utils.HexOrCB58ToID(req.MessageID)
 		if err != nil {
-			logger.Warn("Invalid messageID", zap.String("messageID", req.MessageID), zap.Error(err))
+			logger.Warn("Invalid messageID", zap.String("messageID", sanitizeLogValue(req.MessageID)), zap.Error(err))
 			http.Error(w, "invalid messageID", http.StatusBadRequest)
 			return
 		}

--- a/signature-aggregator/api/api.go
+++ b/signature-aggregator/api/api.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -209,8 +208,7 @@ func signatureAggregationAPIHandler(
 		)
 		if err != nil {
 			logger.Warn("Failed to aggregate signatures", zap.Error(err))
-			msg := fmt.Errorf("failed to aggregate signatures. error: %w", err).Error()
-			writeJSONError(logger, w, http.StatusInternalServerError, msg)
+			writeJSONError(logger, w, http.StatusInternalServerError, "failed to aggregate signatures")
 			return
 		}
 		resp, err := json.Marshal(


### PR DESCRIPTION
## Why this should be merged
Closes https://claude.ai/security?project=scanproj_019LCMtLJaK3JHExaMcFeX7Z&finding=scan_0147CQq7DscAuJC94T7Q54V3-697868

## How this works
Sanitizes the error output. Doesn't add auth middleware which was suggested.

## How this was tested

## How is this documented